### PR TITLE
Updated dns target to get ssl working and corrected filename

### DIFF
--- a/cds-snc.ca/benefits-avantages.cds-snc.ca.tf
+++ b/cds-snc.ca/benefits-avantages.cds-snc.ca.tf
@@ -3,7 +3,7 @@ resource "aws_route53_record" "benefits-avantages-cds-snc-ca-CNAME" {
     name    = "benefits-avantages.cds-snc.ca"
     type    = "CNAME"
     records = [
-        "benefits-avantages.herokuapp.com"
+        "developmental-raven-b8rd2rn5hu8izdje76h0gom5.herokudns.com"
     ]
     ttl     = "300"
 


### PR DESCRIPTION
SSL isn't working yet on the new subdomain - this is because CNAME targets should use a different [herokudns.com domain](https://help.heroku.com/VKRNVVF5/what-is-the-correct-dns-cname-target-for-my-custom-domains). It's not browsable but in theory this should work.