### PR TITLE
Added an alias or A record

### DIFF
--- a/cds-snc.ca/redirect-apex.tf
+++ b/cds-snc.ca/redirect-apex.tf
@@ -1,0 +1,11 @@
+resource "aws_route53_record" "cds-snc-ca-A" {
+  zone_id = "${aws_route53_zone.cds-snc-ca-public.zone_id}"
+  name    = "cds-snc.ca"
+  type    = "A"
+
+  alias {
+    name                   = "cds-redirect.s3-website.us-east-2.amazonaws.com"
+    zone_id                = "${aws_route53_zone.cds-snc-ca-public.zone_id}"
+    evaluate_target_health = true
+  }
+}


### PR DESCRIPTION
The goal is to redirect traffic from cds-snc.ca to digital.canada.ca. The A record points to a static s3 site set up to redirect to digital.canada.ca: http://cds-redirect.s3-website.us-east-2.amazonaws.com

Not 100% sure this is going to work. Would it be better to try setting it up manually through the web interface first?