### PR TITLE
Add a report-a-cybercrime subdomain for azure

### DIFF
--- a/cds-snc.ca/report-a-cybercrime.cds-snc.ca.tf
+++ b/cds-snc.ca/report-a-cybercrime.cds-snc.ca.tf
@@ -1,0 +1,10 @@
+resource "aws_route53_record" "report-a-cybercrime.cds-snc.ca-A" {
+    zone_id = "${aws_route53_zone.cds-snc-ca-public.zone_id}"
+    name    = "report-a-cybercrime.cds-snc.ca"
+    type    = "A"
+    records = [
+			"40.85.218.68"
+    ]
+    ttl     = "300"
+
+}

--- a/cds-snc.ca/signalez-un-crime-informatique.cds-snc.ca.tf
+++ b/cds-snc.ca/signalez-un-crime-informatique.cds-snc.ca.tf
@@ -1,6 +1,6 @@
-resource "aws_route53_record" "report-a-cybercrime-cds-snc-ca-A" {
+resource "aws_route53_record" "signalez-un-crime-informatique-cds-snc-ca-A" {
     zone_id = "${aws_route53_zone.cds-snc-ca-public.zone_id}"
-    name    = "report-a-cybercrime.cds-snc.ca"
+    name    = "signalez-un-crime-informatique.cds-snc.ca"
     type    = "A"
     records = [
 			"40.85.218.68"


### PR DESCRIPTION
This adds an A record for the report-a-cybercrime.cds-snc.ca.
The intent here is to have a domain we can use for setting up TLS config
as we work with getting our app running on Azure.