### PR TITLE
Update Azure IPs again

### DIFF
--- a/cds-snc.ca/report-a-cybercrime.cds-snc.ca.tf
+++ b/cds-snc.ca/report-a-cybercrime.cds-snc.ca.tf
@@ -3,7 +3,7 @@ resource "aws_route53_record" "report-a-cybercrime-cds-snc-ca-A" {
     name    = "report-a-cybercrime.cds-snc.ca"
     type    = "A"
     records = [
-      "52.138.16.103"
+      "52.138.24.130"
     ]
     ttl     = "300"
 

--- a/cds-snc.ca/signalez-un-crime-informatique.cds-snc.ca.tf
+++ b/cds-snc.ca/signalez-un-crime-informatique.cds-snc.ca.tf
@@ -3,7 +3,7 @@ resource "aws_route53_record" "signalez-un-crime-informatique-cds-snc-ca-A" {
     name    = "signalez-un-crime-informatique.cds-snc.ca"
     type    = "A"
     records = [
-      "52.138.16.103"
+      "52.138.24.130"
     ]
     ttl     = "300"
 


### PR DESCRIPTION
Apparently the static IP you can assign is associated with the
"nodeResourceGroup" which is specific to each cluster.