### PR TITLE
[UPDATE] Swap out CNAME for A record alpha.canada.ca

### DIFF
--- a/terraform/alpha.canada.ca-zone.tf
+++ b/terraform/alpha.canada.ca-zone.tf
@@ -14,9 +14,12 @@ output "alpha-canada-ca-ns" {
 resource "aws_route53_record" "alpha-canada-ca-CNAME" {
     zone_id = "${aws_route53_zone.alpha-canada-ca-public.zone_id}"
     name    = "alpha.canada.ca"
-    type    = "CNAME"
+    type    = "A"
     records = [
-        "alpha-canada-ca.github.io"
+        "185.199.108.153",
+        "185.199.109.153",
+        "185.199.110.153",
+        "185.199.111.153"
     ]
     ttl     = "300"
 


### PR DESCRIPTION
Route53 doesn't support cname records on apex domains. 

Interestingly enough, terraform plan didn't fail on this. :/