### PR TITLE
Breaking the rescheduler

### DIFF
--- a/terraform/rescheduler.cds-snc.ca.tf
+++ b/terraform/rescheduler.cds-snc.ca.tf
@@ -1,25 +1,3 @@
-resource "aws_route53_record" "rescheduler-cds-snc-ca-CNAME" {
-    zone_id = "${aws_route53_zone.cds-snc-ca-public.zone_id}"
-    name    = "rescheduler.cds-snc.ca"
-    type    = "CNAME"
-    records = [
-        "d24ti2cjx5hdfv.cloudfront.net"
-    ]
-    ttl     = "300"
-
-}
-
-resource "aws_route53_record" "wildcard-rescheduler-cds-snc-ca-CNAME" {
-    zone_id = "${aws_route53_zone.cds-snc-ca-public.zone_id}"
-    name    = "*.rescheduler.cds-snc.ca"
-    type    = "CNAME"
-    records = [
-        "d24ti2cjx5hdfv.cloudfront.net"
-    ]
-    ttl     = "300"
-
-}
-
 resource "aws_route53_record" "_acme-challenge-rescheduler-cds-snc-ca-TXT" {
     zone_id = "${aws_route53_zone.cds-snc-ca-public.zone_id}"
     name    = "_acme-challenge.rescheduler.cds-snc.ca"


### PR DESCRIPTION
If your DNS record points to a distribution that is not the distribution that you are creating or modifying, then you can't add the alternate domain name to your distribution. In this scenario, you must update your DNS at your DNS provider before you can add the domain name for your CloudFront distribution.


https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/CNAMEs.html#alternate-domain-names-restrictions

the old one is already pointing to a distribution