### PR TITLE
Add in failover data

### DIFF
--- a/terraform/notification.alpha.canada.ca.tf
+++ b/terraform/notification.alpha.canada.ca.tf
@@ -1,12 +1,37 @@
 resource "aws_route53_record" "notification-alpha-canada-ca-A" {
     zone_id = "${aws_route53_zone.alpha-canada-ca-public.zone_id}"
     name    = "notification.alpha.canada.ca"
-    type    = "CNAME"
-    records = [
-        "ac88d4ecee38411e9bb370e1a3d936eb-1183239765.us-east-1.elb.amazonaws.com"
-    ]
-    ttl     = "300"
+    type    = "A"
 
+    set_identifier = "notification.alpha.canada.ca-Primary"
+
+    failover_routing_policy {
+        type = "PRIMARY"
+    }
+
+    alias {
+        name                   = "dualstack.ac88d4ecee38411e9bb370e1a3d936eb-1183239765.us-east-1.elb.amazonaws.com."
+        zone_id                = "Z35SXDOTRQ7X7K"
+        evaluate_target_health = true
+    }
+}
+
+resource "aws_route53_record" "notification-alpha-canada-ca-A-failover" {
+    zone_id = "${aws_route53_zone.alpha-canada-ca-public.zone_id}"
+    name    = "notification.alpha.canada.ca"
+    type    = "A"
+
+    set_identifier = "notification.alpha.canada.ca-Secondary"
+
+    failover_routing_policy {
+        type = "SECONDARY"
+    }
+    
+    alias {
+        name                   = "s3-website.ca-central-1.amazonaws.com"
+        zone_id                = "Z1QDHH18159H29"
+        evaluate_target_health = false
+    }
 }
 
 resource "aws_route53_record" "api-notification-alpha-canada-ca-A" {


### PR DESCRIPTION
Added a secondary record for `notification.alpha.canada.ca` that will trigger if the healthcheck on the primary record fails