### PR TITLE
Changed format for tf 0.12.16 validation errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ On merge, changes are deployed to Route53 automatically by a CircleCI job.
 Subdomain with a CNAME record directing traffic to a Cloudfront endpoint:
 ```
 resource "aws_route53_record" "wildcard-rescheduler-cds-snc-ca-CNAME" {
-    zone_id = "${aws_route53_zone.cds-snc-ca-public.zone_id}"
+    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
     name    = "*.rescheduler.cds-snc.ca"
     type    = "CNAME"
     records = [
@@ -33,7 +33,7 @@ resource "aws_route53_record" "wildcard-rescheduler-cds-snc-ca-CNAME" {
 Subdomain with an A record directing traffic to an IP address:
 ```
 resource "aws_route53_record" "ebrief-cds-snc-ca-A" {
-    zone_id = "${aws_route53_zone.cds-snc-ca-public.zone_id}"
+    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
     name    = "ebrief.cds-snc.ca"
     type    = "A"
     records = [

--- a/terraform/a11y.cds-snc.ca.tf
+++ b/terraform/a11y.cds-snc.ca.tf
@@ -1,5 +1,5 @@
 resource "aws_route53_record" "a11y-cds-snc-ca-CNAME" {
-    zone_id = "${aws_route53_zone.cds-snc-ca-public.zone_id}"
+    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
     name    = "a11y.cds-snc.ca"
     type    = "CNAME"
     records = [

--- a/terraform/alpha.canada.ca-zone.tf
+++ b/terraform/alpha.canada.ca-zone.tf
@@ -12,7 +12,7 @@ output "alpha-canada-ca-ns" {
 }
 
 resource "aws_route53_record" "alpha-canada-ca-alias" {
-    zone_id = "${aws_route53_zone.alpha-canada-ca-public.zone_id}"
+    zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
     name    = "alpha.canada.ca"
     type    = "A"
     alias {
@@ -23,7 +23,7 @@ resource "aws_route53_record" "alpha-canada-ca-alias" {
 }
 
 resource "aws_route53_record" "_b3259586aedbdb670a1126167ef4fad9-alpha-canada-ca-CNAME" {
-    zone_id = "${aws_route53_zone.alpha-canada-ca-public.zone_id}"
+    zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
     name    = "_b3259586aedbdb670a1126167ef4fad9.alpha.canada.ca"
     type    = "CNAME"
     records = [

--- a/terraform/alpha.cds-snc.ca.tf
+++ b/terraform/alpha.cds-snc.ca.tf
@@ -1,5 +1,5 @@
 resource "aws_route53_record" "alpha-cds-snc-ca-ns" {
-  zone_id = "${aws_route53_zone.cds-snc-ca-public.zone_id}"
+  zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
   name    = "alpha.cds-snc.ca"
   type    = "NS"
   ttl     = "30"
@@ -13,7 +13,7 @@ resource "aws_route53_record" "alpha-cds-snc-ca-ns" {
 }
 
 resource "aws_route53_record" "notification-alpha-cds-snc-ca-A" {
-  zone_id = "${aws_route53_zone.cds-snc-ca-public.zone_id}"
+  zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
   name    = "notification.alpha.cds-snc.ca"
   type    = "A"
   records = [

--- a/terraform/benefits-avantages.cds-snc.ca.tf
+++ b/terraform/benefits-avantages.cds-snc.ca.tf
@@ -1,5 +1,5 @@
 resource "aws_route53_record" "benefits-avantages-cds-snc-ca-CNAME" {
-    zone_id = "${aws_route53_zone.cds-snc-ca-public.zone_id}"
+    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
     name    = "benefits-avantages.cds-snc.ca"
     type    = "CNAME"
     records = [

--- a/terraform/branch-review-apps.cds-snc.ca.tf
+++ b/terraform/branch-review-apps.cds-snc.ca.tf
@@ -1,5 +1,5 @@
 resource "aws_route53_record" "branch-review-apps-cds-snc-ca-A" {
-    zone_id = "${aws_route53_zone.cds-snc-ca-public.zone_id}"
+    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
     name    = "branch-review-apps.cds-snc.ca"
     type    = "A"
     records = [

--- a/terraform/cds-snc.ca.tf
+++ b/terraform/cds-snc.ca.tf
@@ -1,5 +1,5 @@
 resource "aws_route53_record" "cds-snc-ca-A" {
-  zone_id = "${aws_route53_zone.cds-snc-ca-public.zone_id}"
+  zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
   name    = "cds-snc.ca"
   type    = "A"
 
@@ -11,7 +11,7 @@ resource "aws_route53_record" "cds-snc-ca-A" {
 }
 
 resource "aws_route53_record" "cds-snc-ca-MX" {
-    zone_id = "${aws_route53_zone.cds-snc-ca-public.zone_id}"
+    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
     name    = "cds-snc.ca"
     type    = "MX"
     records = [
@@ -27,7 +27,7 @@ resource "aws_route53_record" "cds-snc-ca-MX" {
 }
 
 resource "aws_route53_record" "cds-snc-ca-NS" {
-    zone_id = "${aws_route53_zone.cds-snc-ca-public.zone_id}"
+    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
     name    = "cds-snc.ca"
     type    = "NS"
     records = [
@@ -41,7 +41,7 @@ resource "aws_route53_record" "cds-snc-ca-NS" {
 }
 
 resource "aws_route53_record" "cds-snc-ca-SOA" {
-    zone_id = "${aws_route53_zone.cds-snc-ca-public.zone_id}"
+    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
     name    = "cds-snc.ca"
     type    = "SOA"
     records = [
@@ -53,7 +53,7 @@ resource "aws_route53_record" "cds-snc-ca-SOA" {
 
 # SES Domain ownership for IRCC account
 resource "aws_route53_record" "_amazonses-cds-snc-ca-TXT" {
-    zone_id = "${aws_route53_zone.cds-snc-ca-public.zone_id}"
+    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
     name    = "_amazonses.cds-snc.ca"
     type    = "TXT"
     records = [
@@ -65,7 +65,7 @@ resource "aws_route53_record" "_amazonses-cds-snc-ca-TXT" {
 }
 
 resource "aws_route53_record" "_c77e17ef5146ea6fd6ba71f12813c9dc-cds-snc-ca-CNAME" {
-    zone_id = "${aws_route53_zone.cds-snc-ca-public.zone_id}"
+    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
     name    = "_c77e17ef5146ea6fd6ba71f12813c9dc.cds-snc.ca"
     type    = "CNAME"
     records = [
@@ -76,7 +76,7 @@ resource "aws_route53_record" "_c77e17ef5146ea6fd6ba71f12813c9dc-cds-snc-ca-CNAM
 }
 
 resource "aws_route53_record" "doxsxvr6k6upbjhr2ruxm4mqtrxiehuw-_domainkey-cds-snc-ca-CNAME" {
-    zone_id = "${aws_route53_zone.cds-snc-ca-public.zone_id}"
+    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
     name    = "doxsxvr6k6upbjhr2ruxm4mqtrxiehuw._domainkey.cds-snc.ca"
     type    = "CNAME"
     records = [
@@ -87,7 +87,7 @@ resource "aws_route53_record" "doxsxvr6k6upbjhr2ruxm4mqtrxiehuw-_domainkey-cds-s
 }
 
 resource "aws_route53_record" "google-_domainkey-cds-snc-ca-TXT" {
-    zone_id = "${aws_route53_zone.cds-snc-ca-public.zone_id}"
+    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
     name    = "google._domainkey.cds-snc.ca"
     type    = "TXT"
     records = [
@@ -98,7 +98,7 @@ resource "aws_route53_record" "google-_domainkey-cds-snc-ca-TXT" {
 }
 
 resource "aws_route53_record" "huaraq4dvcwl4dfjicrvjuyhod2zgyvz-_domainkey-cds-snc-ca-CNAME" {
-    zone_id = "${aws_route53_zone.cds-snc-ca-public.zone_id}"
+    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
     name    = "huaraq4dvcwl4dfjicrvjuyhod2zgyvz._domainkey.cds-snc.ca"
     type    = "CNAME"
     records = [
@@ -109,7 +109,7 @@ resource "aws_route53_record" "huaraq4dvcwl4dfjicrvjuyhod2zgyvz-_domainkey-cds-s
 }
 
 resource "aws_route53_record" "scph0917-_domainkey-cds-snc-ca-TXT" {
-    zone_id = "${aws_route53_zone.cds-snc-ca-public.zone_id}"
+    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
     name    = "scph0917._domainkey.cds-snc.ca"
     type    = "TXT"
     records = [
@@ -120,7 +120,7 @@ resource "aws_route53_record" "scph0917-_domainkey-cds-snc-ca-TXT" {
 }
 
 resource "aws_route53_record" "vqrxkdrwqioudvaw3rrvwb2c6yre5673-_domainkey-cds-snc-ca-CNAME" {
-    zone_id = "${aws_route53_zone.cds-snc-ca-public.zone_id}"
+    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
     name    = "vqrxkdrwqioudvaw3rrvwb2c6yre5673._domainkey.cds-snc.ca"
     type    = "CNAME"
     records = [
@@ -132,7 +132,7 @@ resource "aws_route53_record" "vqrxkdrwqioudvaw3rrvwb2c6yre5673-_domainkey-cds-s
 
 # DKIM records for IRCC account
 resource "aws_route53_record" "jmdsjkhll6xcr45eceudowr3i5biw7m4-_domainkey-cds-snc-ca-CNAME" {
-    zone_id = "${aws_route53_zone.cds-snc-ca-public.zone_id}"
+    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
     name    = "jmdsjkhll6xcr45eceudowr3i5biw7m4._domainkey.cds-snc.ca"
     type    = "CNAME"
     records = [
@@ -144,7 +144,7 @@ resource "aws_route53_record" "jmdsjkhll6xcr45eceudowr3i5biw7m4-_domainkey-cds-s
 
 # DKIM records for IRCC account
 resource "aws_route53_record" "k64c4rhiqy2utki3pdklkmx4yddgfsvz-_domainkey-cds-snc-ca-CNAME" {
-    zone_id = "${aws_route53_zone.cds-snc-ca-public.zone_id}"
+    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
     name    = "k64c4rhiqy2utki3pdklkmx4yddgfsvz._domainkey.cds-snc.ca"
     type    = "CNAME"
     records = [
@@ -156,7 +156,7 @@ resource "aws_route53_record" "k64c4rhiqy2utki3pdklkmx4yddgfsvz-_domainkey-cds-s
 
 # DKIM records for IRCC account
 resource "aws_route53_record" "npuzzfyyhodvef3vwrj6qdu4tjqkw5ps-_domainkey-cds-snc-ca-CNAME" {
-    zone_id = "${aws_route53_zone.cds-snc-ca-public.zone_id}"
+    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
     name    = "npuzzfyyhodvef3vwrj6qdu4tjqkw5ps._domainkey.cds-snc.ca"
     type    = "CNAME"
     records = [
@@ -167,7 +167,7 @@ resource "aws_route53_record" "npuzzfyyhodvef3vwrj6qdu4tjqkw5ps-_domainkey-cds-s
 }
 
 resource "aws_route53_record" "cds-snc-ca-TXT" {
-    zone_id = "${aws_route53_zone.cds-snc-ca-public.zone_id}"
+    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
     name    = "cds-snc.ca"
     type    = "TXT"
     records = [

--- a/terraform/claim-tax-benefits.alpha.canada.ca.tf
+++ b/terraform/claim-tax-benefits.alpha.canada.ca.tf
@@ -1,5 +1,5 @@
 resource "aws_route53_record" "claim-tax-benefits-alpha-canada-ca-CNAME" {
-    zone_id = "${aws_route53_zone.alpha-canada-ca-public.zone_id}"
+    zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
     name    = "claim-tax-benefits.alpha.canada.ca"
     type    = "CNAME"
     records = [
@@ -9,7 +9,7 @@ resource "aws_route53_record" "claim-tax-benefits-alpha-canada-ca-CNAME" {
 }
 
 resource "aws_route53_record" "reclamer-des-avantages-fiscaux-alpha-canada-ca-CNAME" {
-    zone_id = "${aws_route53_zone.alpha-canada-ca-public.zone_id}"
+    zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
     name    = "reclamer-des-avantages-fiscaux.alpha.canada.ca"
     type    = "CNAME"
     records = [
@@ -19,7 +19,7 @@ resource "aws_route53_record" "reclamer-des-avantages-fiscaux-alpha-canada-ca-CN
 }
 
 resource "aws_route53_record" "claim-tax-benefits-alpha-canada-ca-aws-dns-CNAME" {
-    zone_id = "${aws_route53_zone.alpha-canada-ca-public.zone_id}"
+    zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
     name    = "_fdae793703c2c7c9c33369c921f965b4.claim-tax-benefits.alpha.canada.ca."
     type    = "CNAME"
     records = [

--- a/terraform/ebrief.cds-snc.ca.tf
+++ b/terraform/ebrief.cds-snc.ca.tf
@@ -1,5 +1,5 @@
 resource "aws_route53_record" "ebrief-cds-snc-ca-A" {
-    zone_id = "${aws_route53_zone.cds-snc-ca-public.zone_id}"
+    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
     name    = "brief-bref.cds-snc.ca"
     type    = "A"
     records = [

--- a/terraform/impact.cds-snc.ca.tf
+++ b/terraform/impact.cds-snc.ca.tf
@@ -1,5 +1,5 @@
 resource "aws_route53_record" "impact-cds-snc-ca-TXT" {
-    zone_id = "${aws_route53_zone.cds-snc-ca-public.zone_id}"
+    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
     name    = "impact.cds-snc.ca"
     type    = "TXT"
     records = [
@@ -10,7 +10,7 @@ resource "aws_route53_record" "impact-cds-snc-ca-TXT" {
 }
 
 resource "aws_route53_record" "mx-_domainkey-impact-cds-snc-ca-TXT" {
-    zone_id = "${aws_route53_zone.cds-snc-ca-public.zone_id}"
+    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
     name    = "mx._domainkey.impact.cds-snc.ca"
     type    = "TXT"
     records = [

--- a/terraform/mailgun.cds-snc.ca.tf
+++ b/terraform/mailgun.cds-snc.ca.tf
@@ -1,5 +1,5 @@
 resource "aws_route53_record" "mailgun-cds-snc-ca-TXT" {
-    zone_id = "${aws_route53_zone.cds-snc-ca-public.zone_id}"
+    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
     name    = "mailgun.cds-snc.ca"
     type    = "TXT"
     records = [
@@ -10,7 +10,7 @@ resource "aws_route53_record" "mailgun-cds-snc-ca-TXT" {
 }
 
 resource "aws_route53_record" "pic-_domainkey-mailgun-cds-snc-ca-TXT" {
-    zone_id = "${aws_route53_zone.cds-snc-ca-public.zone_id}"
+    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
     name    = "pic._domainkey.mailgun.cds-snc.ca"
     type    = "TXT"
     records = [

--- a/terraform/notification.alpha.canada.ca.tf
+++ b/terraform/notification.alpha.canada.ca.tf
@@ -1,5 +1,5 @@
 resource "aws_route53_record" "notification-alpha-canada-ca-A" {
-    zone_id = "${aws_route53_zone.alpha-canada-ca-public.zone_id}"
+    zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
     name    = "notification.alpha.canada.ca"
     type    = "A"
 
@@ -17,7 +17,7 @@ resource "aws_route53_record" "notification-alpha-canada-ca-A" {
 }
 
 resource "aws_route53_record" "notification-alpha-canada-ca-A-failover" {
-    zone_id = "${aws_route53_zone.alpha-canada-ca-public.zone_id}"
+    zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
     name    = "notification.alpha.canada.ca"
     type    = "A"
 
@@ -35,7 +35,7 @@ resource "aws_route53_record" "notification-alpha-canada-ca-A-failover" {
 }
 
 resource "aws_route53_record" "api-notification-alpha-canada-ca-A" {
-    zone_id = "${aws_route53_zone.alpha-canada-ca-public.zone_id}"
+    zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
     name    = "api.notification.alpha.canada.ca"
     type    = "CNAME"
     records = [
@@ -46,7 +46,7 @@ resource "aws_route53_record" "api-notification-alpha-canada-ca-A" {
 }
 
 resource "aws_route53_record" "document-notification-alpha-canada-ca-A" {
-    zone_id = "${aws_route53_zone.alpha-canada-ca-public.zone_id}"
+    zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
     name    = "document.notification.alpha.canada.ca"
     type    = "CNAME"
     records = [
@@ -57,7 +57,7 @@ resource "aws_route53_record" "document-notification-alpha-canada-ca-A" {
 }
 
 resource "aws_route53_record" "api-document-notification-alpha-canada-ca-A" {
-    zone_id = "${aws_route53_zone.alpha-canada-ca-public.zone_id}"
+    zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
     name    = "api.document.notification.alpha.canada.ca"
     type    = "CNAME"
     records = [
@@ -69,7 +69,7 @@ resource "aws_route53_record" "api-document-notification-alpha-canada-ca-A" {
 
 
 resource "aws_route53_record" "amazonses-notification-alpha-canada-ca-TXT" {
-    zone_id = "${aws_route53_zone.alpha-canada-ca-public.zone_id}"
+    zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
     name    = "_amazonses.notification.alpha.canada.ca"
     type    = "TXT"
     records = [
@@ -80,7 +80,7 @@ resource "aws_route53_record" "amazonses-notification-alpha-canada-ca-TXT" {
 }
 
 resource "aws_route53_record" "dkim1-notification-alpha-canada-ca-CNAME" {
-    zone_id = "${aws_route53_zone.alpha-canada-ca-public.zone_id}"
+    zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
     name    = "vqaz5umlocfrnmfbflvju6qduqut7i5h._domainkey.notification.alpha.canada.ca"
     type    = "CNAME"
     records = [
@@ -91,7 +91,7 @@ resource "aws_route53_record" "dkim1-notification-alpha-canada-ca-CNAME" {
 }
 
 resource "aws_route53_record" "dkim2-notification-alpha-canada-ca-CNAME" {
-    zone_id = "${aws_route53_zone.alpha-canada-ca-public.zone_id}"
+    zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
     name    = "hofufbbtcrcvxie3vngnqb6ew3p4qjst._domainkey.notification.alpha.canada.ca"
     type    = "CNAME"
     records = [
@@ -102,7 +102,7 @@ resource "aws_route53_record" "dkim2-notification-alpha-canada-ca-CNAME" {
 }
 
 resource "aws_route53_record" "dkim3-notification-alpha-canada-ca-CNAME" {
-    zone_id = "${aws_route53_zone.alpha-canada-ca-public.zone_id}"
+    zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
     name    = "t2ihvmsa65nqcjuemxykbsivxbqhecg7._domainkey.notification.alpha.canada.ca"
     type    = "CNAME"
     records = [
@@ -113,7 +113,7 @@ resource "aws_route53_record" "dkim3-notification-alpha-canada-ca-CNAME" {
 }
 
 resource "aws_route53_record" "notification-alpha-canada-ca-SPF" {
-    zone_id = "${aws_route53_zone.alpha-canada-ca-public.zone_id}"
+    zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
     name    = "notification.alpha.canada.ca"
     type    = "TXT"
     records = [
@@ -124,7 +124,7 @@ resource "aws_route53_record" "notification-alpha-canada-ca-SPF" {
 }
 
 resource "aws_route53_record" "notification-alpha-canada-ca-DMARC" {
-    zone_id = "${aws_route53_zone.alpha-canada-ca-public.zone_id}"
+    zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
     name    = "_dmarc.notification.alpha.canada.ca"
     type    = "TXT"
     records = [

--- a/terraform/nrcan-energuide-poc.cds-snc.ca.tf
+++ b/terraform/nrcan-energuide-poc.cds-snc.ca.tf
@@ -1,5 +1,5 @@
 resource "aws_route53_record" "nrcan-energuide-poc-cds-snc-ca-A" {
-    zone_id = "${aws_route53_zone.cds-snc-ca-public.zone_id}"
+    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
     name    = "nrcan-energuide-poc.cds-snc.ca"
     type    = "A"
     records = [

--- a/terraform/nrcanapi.cds-snc.ca.tf
+++ b/terraform/nrcanapi.cds-snc.ca.tf
@@ -1,5 +1,5 @@
 resource "aws_route53_record" "nrcanapi-cds-snc-ca-A" {
-    zone_id = "${aws_route53_zone.cds-snc-ca-public.zone_id}"
+    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
     name    = "nrcanapi.cds-snc.ca"
     type    = "A"
     records = [

--- a/terraform/privacy-statements.alpha.canada.ca.tf
+++ b/terraform/privacy-statements.alpha.canada.ca.tf
@@ -1,5 +1,5 @@
 resource "aws_route53_record" "privacy-statements-cds-alpha-canada-ca-CNAME" {
-    zone_id = "${aws_route53_zone.alpha-canada-ca-public.zone_id}"
+    zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
     name    = "privacy-statements.cds.alpha.canada.ca"
     type    = "CNAME"
     records = [
@@ -9,7 +9,7 @@ resource "aws_route53_record" "privacy-statements-cds-alpha-canada-ca-CNAME" {
 }
 
 resource "aws_route53_record" "avis-confidentialite-snc-alpha-canada-ca-CNAME" {
-    zone_id = "${aws_route53_zone.alpha-canada-ca-public.zone_id}"
+    zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
     name    = "avis-confidentialite.snc.alpha.canada.ca"
     type    = "CNAME"
     records = [

--- a/terraform/report-a-cybercrime.cds-snc.ca.tf
+++ b/terraform/report-a-cybercrime.cds-snc.ca.tf
@@ -1,5 +1,5 @@
 resource "aws_route53_record" "report-a-cybercrime-cds-snc-ca-A" {
-    zone_id = "${aws_route53_zone.cds-snc-ca-public.zone_id}"
+    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
     name    = "report-a-cybercrime.cds-snc.ca"
     type    = "A"
     records = [

--- a/terraform/rescheduler-dev.cds-snc.ca.tf
+++ b/terraform/rescheduler-dev.cds-snc.ca.tf
@@ -1,5 +1,5 @@
 resource "aws_route53_record" "rescheduler-dev-cds-snc-ca-CNAME" {
-    zone_id = "${aws_route53_zone.cds-snc-ca-public.zone_id}"
+    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
     name    = "rescheduler-dev.cds-snc.ca"
     type    = "CNAME"
     records = [
@@ -10,7 +10,7 @@ resource "aws_route53_record" "rescheduler-dev-cds-snc-ca-CNAME" {
 }
 
 resource "aws_route53_record" "wildcard-rescheduler-dev-cds-snc-ca-CNAME" {
-    zone_id = "${aws_route53_zone.cds-snc-ca-public.zone_id}"
+    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
     name    = "*.rescheduler-dev.cds-snc.ca"
     type    = "CNAME"
     records = [
@@ -21,7 +21,7 @@ resource "aws_route53_record" "wildcard-rescheduler-dev-cds-snc-ca-CNAME" {
 }
 
 resource "aws_route53_record" "_6ad6e4d2289f5b17d4761e6a95fe53ee-rescheduler-dev-cds-snc-ca-CNAME" {
-    zone_id = "${aws_route53_zone.cds-snc-ca-public.zone_id}"
+    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
     name    = "_6ad6e4d2289f5b17d4761e6a95fe53ee.rescheduler-dev.cds-snc.ca"
     type    = "CNAME"
     records = [
@@ -32,7 +32,7 @@ resource "aws_route53_record" "_6ad6e4d2289f5b17d4761e6a95fe53ee-rescheduler-dev
 }
 
 resource "aws_route53_record" "_acme-challenge-rescheduler-dev-cds-snc-ca-TXT" {
-    zone_id = "${aws_route53_zone.cds-snc-ca-public.zone_id}"
+    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
     name    = "_acme-challenge.rescheduler-dev.cds-snc.ca"
     type    = "TXT"
     records = [

--- a/terraform/rescheduler.alpha.cds-snc.ca.tf
+++ b/terraform/rescheduler.alpha.cds-snc.ca.tf
@@ -1,5 +1,5 @@
 resource "aws_route53_record" "_acm-validation-rescheduler-alpha-cds-snc-ca-CNAME" {
-    zone_id = "${aws_route53_zone.cds-snc-ca-public.zone_id}"
+    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
     name    = "_124e31a4e6b52e341c197ae439978b0e.rescheduler.alpha.cds-snc.ca."
     type    = "CNAME"
     records = [

--- a/terraform/rescheduler.cds-snc.ca.tf
+++ b/terraform/rescheduler.cds-snc.ca.tf
@@ -1,5 +1,5 @@
 resource "aws_route53_record" "rescheduler-cds-snc-ca-CNAME" {
-    zone_id = "${aws_route53_zone.cds-snc-ca-public.zone_id}"
+    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
     name    = "rescheduler.cds-snc.ca"
     type    = "A"
     alias {
@@ -10,7 +10,7 @@ resource "aws_route53_record" "rescheduler-cds-snc-ca-CNAME" {
 }
 
 resource "aws_route53_record" "wildcard-rescheduler-cds-snc-ca-CNAME" {
-    zone_id = "${aws_route53_zone.cds-snc-ca-public.zone_id}"
+    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
     name    = "*.rescheduler.cds-snc.ca"
     type    = "A"
     alias {
@@ -21,7 +21,7 @@ resource "aws_route53_record" "wildcard-rescheduler-cds-snc-ca-CNAME" {
 }
 
 resource "aws_route53_record" "_acme-challenge-rescheduler-cds-snc-ca-TXT" {
-    zone_id = "${aws_route53_zone.cds-snc-ca-public.zone_id}"
+    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
     name    = "_acme-challenge.rescheduler.cds-snc.ca"
     type    = "TXT"
     records = [
@@ -33,7 +33,7 @@ resource "aws_route53_record" "_acme-challenge-rescheduler-cds-snc-ca-TXT" {
 }
 
 resource "aws_route53_record" "_faa1db50e36e98191aefeeb9548c9165-rescheduler-cds-snc-ca-CNAME" {
-    zone_id = "${aws_route53_zone.cds-snc-ca-public.zone_id}"
+    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
     name    = "_faa1db50e36e98191aefeeb9548c9165.rescheduler.cds-snc.ca"
     type    = "CNAME"
     records = [
@@ -44,7 +44,7 @@ resource "aws_route53_record" "_faa1db50e36e98191aefeeb9548c9165-rescheduler-cds
 }
 
 resource "aws_route53_record" "_9ad5e390e0591a7c0fee72f5280dc709-rescheduler-cds-snc-ca-CNAME" {
-    zone_id = "${aws_route53_zone.cds-snc-ca-public.zone_id}"
+    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
     name    = "_9ad5e390e0591a7c0fee72f5280dc709.rescheduler.cds-snc.ca."
     type    = "CNAME"
     records = [

--- a/terraform/service-dashboard.cds-snc.ca.tf
+++ b/terraform/service-dashboard.cds-snc.ca.tf
@@ -1,5 +1,5 @@
 resource "aws_route53_record" "service-dashboard-cds-snc-ca-A" {
-    zone_id = "${aws_route53_zone.cds-snc-ca-public.zone_id}"
+    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
     name    = "service-dashboard.cds-snc.ca"
     type    = "A"
     records = [

--- a/terraform/signalez-un-crime-informatique.cds-snc.ca.tf
+++ b/terraform/signalez-un-crime-informatique.cds-snc.ca.tf
@@ -1,5 +1,5 @@
 resource "aws_route53_record" "signalez-un-crime-informatique-cds-snc-ca-A" {
-    zone_id = "${aws_route53_zone.cds-snc-ca-public.zone_id}"
+    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
     name    = "signalez-un-crime-informatique.cds-snc.ca"
     type    = "A"
     records = [

--- a/terraform/tell-us.cds-snc.ca.tf
+++ b/terraform/tell-us.cds-snc.ca.tf
@@ -1,5 +1,5 @@
 resource "aws_route53_record" "tell-us-cds-snc-ca-A" {
-    zone_id = "${aws_route53_zone.cds-snc-ca-public.zone_id}"
+    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
     name    = "tell-us.cds-snc.ca"
     type    = "A"
     records = [
@@ -10,7 +10,7 @@ resource "aws_route53_record" "tell-us-cds-snc-ca-A" {
 }
 
 resource "aws_route53_record" "racontez-nous-cds-snc-ca-A" {
-    zone_id = "${aws_route53_zone.cds-snc-ca-public.zone_id}"
+    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
     name    = "racontez-nous.cds-snc.ca"
     type    = "A"
     records = [

--- a/terraform/track-digital.cds-snc.ca.tf
+++ b/terraform/track-digital.cds-snc.ca.tf
@@ -1,5 +1,5 @@
 resource "aws_route53_record" "track-digital-dev-cds-snc-ca-CNAME" {
-    zone_id = "${aws_route53_zone.cds-snc-ca-public.zone_id}"
+    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
     name    = "track-digital-dev.cds-snc.ca"
     type    = "CNAME"
     records = [
@@ -10,7 +10,7 @@ resource "aws_route53_record" "track-digital-dev-cds-snc-ca-CNAME" {
 }
 
 resource "aws_route53_record" "track-digital-fr-cds-snc-ca-CNAME" {
-    zone_id = "${aws_route53_zone.cds-snc-ca-public.zone_id}"
+    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
     name    = "track-digital-fr.cds-snc.ca"
     type    = "CNAME"
     records = [
@@ -21,7 +21,7 @@ resource "aws_route53_record" "track-digital-fr-cds-snc-ca-CNAME" {
 }
 
 resource "aws_route53_record" "track-digital-cds-snc-ca-CNAME" {
-    zone_id = "${aws_route53_zone.cds-snc-ca-public.zone_id}"
+    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
     name    = "track-digital.cds-snc.ca"
     type    = "CNAME"
     records = [

--- a/terraform/vac-benefits-finder.cds-snc.ca.tf
+++ b/terraform/vac-benefits-finder.cds-snc.ca.tf
@@ -1,5 +1,5 @@
 resource "aws_route53_record" "vac-benefits-finder-cds-snc-ca-A" {
-    zone_id = "${aws_route53_zone.cds-snc-ca-public.zone_id}"
+    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
     name    = "vac-benefits-finder.cds-snc.ca"
     type    = "A"
     records = [


### PR DESCRIPTION
changed `zone_id = "${aws_route53_zone.cds-snc-ca-public.zone_id}"` to `zone_id = aws_route53_zone.cds-snc-ca-public.zone_id` to turn off the deprecation errors