### PR TITLE
Covid-19 Benefits subdomains

### DIFF
--- a/terraform/covid-benefits.alpha.canada.ca.tf
+++ b/terraform/covid-benefits.alpha.canada.ca.tf
@@ -1,0 +1,19 @@
+resource "aws_route53_record" "covid-benefits-alpha-canada-ca-CNAME" {
+    zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+    name    = "covid-benefits.alpha.canada.ca"
+    type    = "CNAME"
+    records = [
+        "CV19BenefitsCDNEndpoint.azureedge.net"
+    ]
+    ttl     = "300"
+}
+
+resource "aws_route53_record" "covid-prestations-alpha-canada-ca-CNAME" {
+    zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+    name    = "covid-prestations.alpha.canada.ca"
+    type    = "CNAME"
+    records = [
+        "CV19BenefitsCDNEndpoint.azureedge.net"
+    ]
+    ttl     = "300"
+}


### PR DESCRIPTION
Adds English and French subdomains for the Covid-19 Benefits service.

The origin is an Azure CDN, proxying back to Azure App Service.