### PR TITLE
Handover of the COVID 19 Benefits Finder from CDS to ESDC

### DIFF
--- a/terraform/covid-benefits.alpha.canada.ca.tf
+++ b/terraform/covid-benefits.alpha.canada.ca.tf
@@ -3,7 +3,7 @@ resource "aws_route53_record" "covid-benefits-alpha-canada-ca-CNAME" {
     name    = "covid-benefits.alpha.canada.ca"
     type    = "CNAME"
     records = [
-        "cv19benefits-appservice.azurewebsites.net"
+        "espbdtscb19appservice.azurewebsites.net"
     ]
     ttl     = "300"
 }


### PR DESCRIPTION
This should be the last technical step before CDS has fully handed over the Benefit Finder. 

Please note that this is waiting on an ATO from the ESDC side before it can be merged, please do not merge until you recieve approval from DTS Delegated Authority.

This simply changes the CNAME from CDS' AppService to ESDC's AppService. 

After this is done a Custom Domain will have to be added to the AppService
![image](https://user-images.githubusercontent.com/87738/85767399-f9a00000-b6e5-11ea-81b4-145e304452dc.png)

Then we need to confirm that TLS/SSL Bindings have been configured:
![image](https://user-images.githubusercontent.com/87738/85767540-1dfbdc80-b6e6-11ea-8cd6-85dd4663bf9e.png)
