### PR TITLE
Pinning versions for Circle CI and AWS Provider

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   plan:
     docker:
-      - image: hashicorp/terraform:light
+      - image: hashicorp/terraform:v0.12.29
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   plan:
     docker:
-      - image: hashicorp/terraform:v0.12.29
+      - image: hashicorp/terraform:0.12.29
     steps:
       - checkout
       - run:

--- a/terraform/init.tf
+++ b/terraform/init.tf
@@ -1,5 +1,6 @@
 provider "aws" {
   region  = "us-east-1"
+  version = "~> 2.70"
 }
 
 terraform {


### PR DESCRIPTION
This will pin the versions for the terraform image in the Circle CI configuration to `v0.12.29` and will pin the AWS provider version to `~> 2.70`. 

This should fix the issue we are currently having with the DNS TF not applying on merge to master. 