### PR TITLE
Add DMARC to cds-snc.ca

### DIFF
--- a/terraform/cds-snc.ca.tf
+++ b/terraform/cds-snc.ca.tf
@@ -51,6 +51,18 @@ resource "aws_route53_record" "cds-snc-ca-SOA" {
 
 }
 
+# DMARC
+resource "aws_route53_record" "_dmarc-cds-snc-ca-TXT" {
+    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
+    name    = "_dmarc.cds-snc.ca"
+    type    = "TXT"
+    records = [
+        "v=DMARC1; p=none; sp=none; pct=100; rua=mailto:dmarc@cyber.gc.ca"
+    ]
+    ttl     = "300"
+
+}
+
 # SES Domain ownership for IRCC account
 resource "aws_route53_record" "_amazonses-cds-snc-ca-TXT" {
     zone_id = aws_route53_zone.cds-snc-ca-public.zone_id


### PR DESCRIPTION
Adds a monitor-only DMARC record to the root of `cds-snc.ca`, with aggregate reports sent to the Cyber Centre.