### PR TITLE
feat: add new CNAME validation for alpha.canada.ca

### DIFF
--- a/terraform/alpha.canada.ca-zone.tf
+++ b/terraform/alpha.canada.ca-zone.tf
@@ -32,3 +32,14 @@ resource "aws_route53_record" "_b3259586aedbdb670a1126167ef4fad9-alpha-canada-ca
     ttl     = "300"
 
 }
+
+resource "aws_route53_record" "_dbb14456ed8ab3deed1f05507ff40373-alpha-canada-ca-CNAME" {
+    zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+    name    = "_dbb14456ed8ab3deed1f05507ff40373.alpha.canada.ca"
+    type    = "CNAME"
+    records = [
+        "_900ac2c0ff88c1899ffb3e47cd4b42c8.wggjkglgrm.acm-validations.aws."
+    ]
+    ttl     = "300"
+
+}


### PR DESCRIPTION
Adds a CNAME ACM validation for the new alpha.canada.ca home.