### PR TITLE
Change how traffic is routed to COVID Alert Portal

### DIFF
--- a/terraform/covid-alert-portal.alpha.canada.ca.tf
+++ b/terraform/covid-alert-portal.alpha.canada.ca.tf
@@ -3,10 +3,10 @@ resource "aws_route53_record" "covid-alert-portal-alpha-canada-ca-NS" {
   name    = "covid-alert-portal.alpha.canada.ca"
   type    = "NS"
   records = [
-    "ns-1714.awsdns-22.co.uk",
-    "ns-93.awsdns-11.com",
-    "ns-1334.awsdns-38.org",
-    "ns-842.awsdns-41.net"
+    "ns-905.awsdns-49.net",
+    "ns-29.awsdns-03.com",
+    "ns-2045.awsdns-63.co.uk",
+    "ns-1156.awsdns-16.org"
   ]
   ttl = "300"
 }

--- a/terraform/covid-alert-portal.alpha.canada.ca.tf
+++ b/terraform/covid-alert-portal.alpha.canada.ca.tf
@@ -1,40 +1,22 @@
-resource "aws_route53_record" "covid-alert-portal-alpha-canada-ca-CNAME" {
-    zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
-    name    = "covid-alert-portal.alpha.canada.ca"
-    type    = "CNAME"
-    records = [
-        "production.tf.covid-portal.cdssandbox.xyz"
-    ]
-    ttl     = "300"
+resource "aws_route53_record" "covid-alert-portal-alpha-canada-ca-NS" {
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "covid-alert-portal.alpha.canada.ca"
+  type    = "NS"
+  records = [
+    "ns-1714.awsdns-22.co.uk",
+    "ns-93.awsdns-11.com",
+    "ns-1334.awsdns-38.org",
+    "ns-842.awsdns-41.net"
+  ]
+  ttl = "300"
 }
-
 
 resource "aws_route53_record" "portail-alerte-covid-alpha-canada-ca-CNAME" {
-    zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
-    name    = "portail-alerte-covid.alpha.canada.ca"
-    type    = "CNAME"
-    records = [
-        "production.tf.covid-portal.cdssandbox.xyz"
-    ]
-    ttl     = "300"
-}
-
-resource "aws_route53_record" "validation-portail-alerte-covid-alpha-canada-ca-CNAME" {
-    zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
-    name    = "_3ba860f222938a98267338955da3e5ca.portail-alerte-covid.alpha.canada.ca."
-    type    = "CNAME"
-    records = [
-        "_47b1646b80bc5860253dd09b3dde5be4.jfrzftwwjs.acm-validations.aws."
-    ]
-    ttl     = "300"
-}
-
-resource "aws_route53_record" "validation-covid-alert-portal-alpha-canada-ca-CNAME" {
-    zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
-    name    = "_c5a216ebd2eef783096011059aaeb206.covid-alert-portal.alpha.canada.ca."
-    type    = "CNAME"
-    records = [
-        "_655c0c07e4cf58945b17ca3709fe1f5a.jfrzftwwjs.acm-validations.aws."
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "portail-alerte-covid.alpha.canada.ca"
+  type    = "CNAME"
+  records = [
+    "covid-alert-portal.alpha.canada.ca"
+  ]
+  ttl = "300"
 }


### PR DESCRIPTION
# BREAKING CHANGE - Do not merge
This PR removes the current CNAMES and Certificate validation entries and adds the Name Servers for the covid-alert-portal subdomain hosted in AWS.