### PR TITLE
fix: remove old open call CF distribution

### DIFF
--- a/terraform/opencall-appelouvert-alpha-canada.ca.tf
+++ b/terraform/opencall-appelouvert-alpha-canada.ca.tf
@@ -1,13 +1,3 @@
-resource "aws_route53_record" "opencall-appelouvert-alpha-canada-ca-A" {
-  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
-  name    = "opencall-appelouvert.alpha.canada.ca"
-  type    = "CNAME"
-  records = [
-    "dc4vvh422odpa.cloudfront.net"
-  ]
-  ttl     = "300"
-}
-
 resource "aws_route53_record" "_cb979fcab2fc2fecda36a5b4a82f5aa6-opencall-appelouvert-alpha-canada-ca-CNAME" {
     zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
     name    = "_cb979fcab2fc2fecda36a5b4a82f5aa6.opencall-appelouvert.alpha.canada.ca."


### PR DESCRIPTION
Removes the old Cloudfront open call distribution