### PR TITLE
feat: add id.alpha.canada.ca NS delegation

### DIFF
--- a/terraform/id-alpha-canada-ca.tf
+++ b/terraform/id-alpha-canada-ca.tf
@@ -1,0 +1,13 @@
+resource "aws_route53_record" "id-alpha-canada-ca-NS" {
+    zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+    name    = "id.alpha.canada.ca"
+    type    = "NS"
+    records = [
+        "ns1-08.azure-dns.com",
+        "ns2-08.azure-dns.net",
+        "ns3-08.azure-dns.org",
+        "ns4-08.azure-dns.info"
+    ]
+    ttl     = "300"
+
+}


### PR DESCRIPTION
Adds `id.alpha.canada.ca` subdomain delegation to Azure name servers.