### PR TITLE
Add records for documentation.notification.canada.ca

### DIFF
--- a/terraform/notification.canada.ca-zone.tf
+++ b/terraform/notification.canada.ca-zone.tf
@@ -68,6 +68,26 @@ resource "aws_route53_record" "www-notification-canada-ca-CNAME" {
     ttl     = "300"
 }
 
+resource "aws_route53_record" "documentation-notification-canada-ca-CNAME" {
+    zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
+    name    = "documentation.notification.canada.ca"
+    type    = "CNAME"
+    records = [
+        local.notification_alb
+    ]
+    ttl     = "300"
+}
+
+resource "aws_route53_record" "doc-notification-canada-ca-CNAME" {
+    zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
+    name    = "doc.notification.canada.ca"
+    type    = "CNAME"
+    records = [
+        local.notification_alb
+    ]
+    ttl     = "300"
+}
+
 resource "aws_route53_record" "notification-canada-ca-ACM-cname" {
     zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
     name    = "_2115a5004ab7895234c60254e152046b.notification.canada.ca"


### PR DESCRIPTION
Notify will soon have its own documentation website so I'm preparing DNS records.

- documentation.notification.canada.ca will be the main domain
- doc.notification.canada.ca is a convenience domain and will redirect to the main one

Git repo: https://github.com/cds-snc/notification-documentation
Current preview: https://cds-snc.github.io/notification-documentation/