### PR TITLE
feat: upgrade Terraform to 0.13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   plan:
     docker:
-      - image: hashicorp/terraform:0.12.29
+      - image: hashicorp/terraform:0.13.6
     steps:
       - checkout
       - run:
@@ -32,7 +32,7 @@ jobs:
 
   apply:
     docker:
-      - image: hashicorp/terraform:0.12.29
+      - image: hashicorp/terraform:0.13.6
     steps:
       - attach_workspace:
           at: .

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+fmt:
+	terraform fmt -recursive bootstrap
+	terraform fmt -recursive terraform

--- a/bootstrap/init.tf
+++ b/bootstrap/init.tf
@@ -8,7 +8,7 @@ terraform {
 }
 
 provider "aws" {
-  region  = "us-east-1"
+  region = "us-east-1"
 }
 
 
@@ -27,7 +27,7 @@ resource "aws_iam_user" "deployer" {
 
 resource "aws_iam_user_policy" "circleci_deployer_policy" {
   name = "route53-deployment"
-  user = "${aws_iam_user.deployer.name}"
+  user = aws_iam_user.deployer.name
 
   policy = <<EOF
 {

--- a/bootstrap/init.tf
+++ b/bootstrap/init.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 2.70"
+    }
+  }
+}
+
 provider "aws" {
   region  = "us-east-1"
 }

--- a/terraform/a11y.cds-snc.ca.tf
+++ b/terraform/a11y.cds-snc.ca.tf
@@ -1,10 +1,10 @@
 resource "aws_route53_record" "a11y-cds-snc-ca-CNAME" {
-    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
-    name    = "a11y.cds-snc.ca"
-    type    = "CNAME"
-    records = [
-        "flexible-anenome-2mbipgu5nzz78n86sbnndcvk.herokudns.com"
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
+  name    = "a11y.cds-snc.ca"
+  type    = "CNAME"
+  records = [
+    "flexible-anenome-2mbipgu5nzz78n86sbnndcvk.herokudns.com"
+  ]
+  ttl = "300"
 
 }

--- a/terraform/alpha.canada.ca-zone.tf
+++ b/terraform/alpha.canada.ca-zone.tf
@@ -1,10 +1,10 @@
 resource "aws_route53_zone" "alpha-canada-ca-public" {
-    name       = "alpha.canada.ca"
-    comment    = ""
+  name    = "alpha.canada.ca"
+  comment = ""
 
-    tags = {
-        Project = "dns"
-    }
+  tags = {
+    Project = "dns"
+  }
 }
 
 output "alpha-canada-ca-ns" {
@@ -12,34 +12,34 @@ output "alpha-canada-ca-ns" {
 }
 
 resource "aws_route53_record" "alpha-canada-ca-alias" {
-    zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
-    name    = "alpha.canada.ca"
-    type    = "A"
-    alias {
-        name                   = "d188wm8umhgzev.cloudfront.net"
-        zone_id                = "Z2FDTNDATAQYW2"
-        evaluate_target_health = true
-    }
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "alpha.canada.ca"
+  type    = "A"
+  alias {
+    name                   = "d188wm8umhgzev.cloudfront.net"
+    zone_id                = "Z2FDTNDATAQYW2"
+    evaluate_target_health = true
+  }
 }
 
 resource "aws_route53_record" "_b3259586aedbdb670a1126167ef4fad9-alpha-canada-ca-CNAME" {
-    zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
-    name    = "_b3259586aedbdb670a1126167ef4fad9.alpha.canada.ca"
-    type    = "CNAME"
-    records = [
-        "_86256a6d6c75bfd5e57ca09b9f3d51b8.kirrbxfjtw.acm-validations.aws"
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "_b3259586aedbdb670a1126167ef4fad9.alpha.canada.ca"
+  type    = "CNAME"
+  records = [
+    "_86256a6d6c75bfd5e57ca09b9f3d51b8.kirrbxfjtw.acm-validations.aws"
+  ]
+  ttl = "300"
 
 }
 
 resource "aws_route53_record" "_dbb14456ed8ab3deed1f05507ff40373-alpha-canada-ca-CNAME" {
-    zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
-    name    = "_dbb14456ed8ab3deed1f05507ff40373.alpha.canada.ca"
-    type    = "CNAME"
-    records = [
-        "_900ac2c0ff88c1899ffb3e47cd4b42c8.wggjkglgrm.acm-validations.aws."
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "_dbb14456ed8ab3deed1f05507ff40373.alpha.canada.ca"
+  type    = "CNAME"
+  records = [
+    "_900ac2c0ff88c1899ffb3e47cd4b42c8.wggjkglgrm.acm-validations.aws."
+  ]
+  ttl = "300"
 
 }

--- a/terraform/alpha.canada.ca-zone.tf
+++ b/terraform/alpha.canada.ca-zone.tf
@@ -8,7 +8,7 @@ resource "aws_route53_zone" "alpha-canada-ca-public" {
 }
 
 output "alpha-canada-ca-ns" {
-  value="${aws_route53_zone.alpha-canada-ca-public.name_servers}"
+  value = aws_route53_zone.alpha-canada-ca-public.name_servers
 }
 
 resource "aws_route53_record" "alpha-canada-ca-alias" {

--- a/terraform/alpha.cds-snc.ca.tf
+++ b/terraform/alpha.cds-snc.ca.tf
@@ -19,6 +19,6 @@ resource "aws_route53_record" "notification-alpha-cds-snc-ca-A" {
   records = [
     "35.203.112.92"
   ]
-  ttl     = "300"
-   
+  ttl = "300"
+
 }

--- a/terraform/backend.tfvars
+++ b/terraform/backend.tfvars
@@ -1,2 +1,2 @@
 bucket = "cds-dns-terraform-state"
-key = "terraform.tfstate"
+key    = "terraform.tfstate"

--- a/terraform/benefits-avantages.cds-snc.ca.tf
+++ b/terraform/benefits-avantages.cds-snc.ca.tf
@@ -1,10 +1,10 @@
 resource "aws_route53_record" "benefits-avantages-cds-snc-ca-CNAME" {
-    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
-    name    = "benefits-avantages.cds-snc.ca"
-    type    = "CNAME"
-    records = [
-        "developmental-raven-b8rd2rn5hu8izdje76h0gom5.herokudns.com"
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
+  name    = "benefits-avantages.cds-snc.ca"
+  type    = "CNAME"
+  records = [
+    "developmental-raven-b8rd2rn5hu8izdje76h0gom5.herokudns.com"
+  ]
+  ttl = "300"
 
 }

--- a/terraform/beta.canada.ca-zone.tf
+++ b/terraform/beta.canada.ca-zone.tf
@@ -1,10 +1,10 @@
 resource "aws_route53_zone" "beta-canada-ca-public" {
-    name       = "beta.canada.ca"
-    comment    = ""
+  name    = "beta.canada.ca"
+  comment = ""
 
-    tags = {
-        Project = "dns"
-    }
+  tags = {
+    Project = "dns"
+  }
 }
 
 output "beta-canada-ca-ns" {

--- a/terraform/beta.canada.ca-zone.tf
+++ b/terraform/beta.canada.ca-zone.tf
@@ -8,5 +8,5 @@ resource "aws_route53_zone" "beta-canada-ca-public" {
 }
 
 output "beta-canada-ca-ns" {
-  value="${aws_route53_zone.beta-canada-ca-public.name_servers}"
+  value = aws_route53_zone.beta-canada-ca-public.name_servers
 }

--- a/terraform/branch-review-apps.cds-snc.ca.tf
+++ b/terraform/branch-review-apps.cds-snc.ca.tf
@@ -1,10 +1,10 @@
 resource "aws_route53_record" "branch-review-apps-cds-snc-ca-A" {
-    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
-    name    = "branch-review-apps.cds-snc.ca"
-    type    = "A"
-    records = [
-        "35.202.225.254"
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
+  name    = "branch-review-apps.cds-snc.ca"
+  type    = "A"
+  records = [
+    "35.202.225.254"
+  ]
+  ttl = "300"
 
 }

--- a/terraform/cds-snc.ca-zone.tf
+++ b/terraform/cds-snc.ca-zone.tf
@@ -1,10 +1,10 @@
 resource "aws_route53_zone" "cds-snc-ca-public" {
-    name       = "cds-snc.ca"
-    comment    = ""
+  name    = "cds-snc.ca"
+  comment = ""
 
-    tags = {
-        Project = "dns"
-    }
+  tags = {
+    Project = "dns"
+  }
 }
 
 output "cds-snc-ca-ns" {

--- a/terraform/cds-snc.ca-zone.tf
+++ b/terraform/cds-snc.ca-zone.tf
@@ -8,5 +8,5 @@ resource "aws_route53_zone" "cds-snc-ca-public" {
 }
 
 output "cds-snc-ca-ns" {
-  value="${aws_route53_zone.cds-snc-ca-public.name_servers}"
+  value = aws_route53_zone.cds-snc-ca-public.name_servers
 }

--- a/terraform/cds-snc.ca.tf
+++ b/terraform/cds-snc.ca.tf
@@ -11,262 +11,262 @@ resource "aws_route53_record" "cds-snc-ca-A" {
 }
 
 resource "aws_route53_record" "cds-snc-ca-MX" {
-    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
-    name    = "cds-snc.ca"
-    type    = "MX"
-    records = [
-        "1 aspmx.l.google.com.",
-        "5 alt1.aspmx.l.google.com.",
-        "5 alt2.aspmx.l.google.com.",
-        "10 alt3.aspmx.l.google.com.",
-        "10 alt4.aspmx.l.google.com.",
-        "15 2ucw6y27ggthkqfli3z6jt7ctyyzkkuij2gdrw4wwtvljx7tawbq.mx-verification.google.com."
-    ]
-    ttl     = "1800"
+  zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
+  name    = "cds-snc.ca"
+  type    = "MX"
+  records = [
+    "1 aspmx.l.google.com.",
+    "5 alt1.aspmx.l.google.com.",
+    "5 alt2.aspmx.l.google.com.",
+    "10 alt3.aspmx.l.google.com.",
+    "10 alt4.aspmx.l.google.com.",
+    "15 2ucw6y27ggthkqfli3z6jt7ctyyzkkuij2gdrw4wwtvljx7tawbq.mx-verification.google.com."
+  ]
+  ttl = "1800"
 
 }
 
 # DMARC Policy, currently in audit mode, progress to reject mode after review.
 resource "aws_route53_record" "_dmarc-cds-snc-ca-TXT" {
-    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
-    name    = "_dmarc.cds-snc.ca"
-    type    = "TXT"
-    records = [
-        "v=DMARC1; p=none; sp=none; pct=100; rua=mailto:dmarc@cyber.gc.ca"
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
+  name    = "_dmarc.cds-snc.ca"
+  type    = "TXT"
+  records = [
+    "v=DMARC1; p=none; sp=none; pct=100; rua=mailto:dmarc@cyber.gc.ca"
+  ]
+  ttl = "300"
 
 }
 
 resource "aws_route53_record" "cds-snc-ca-NS" {
-    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
-    name    = "cds-snc.ca"
-    type    = "NS"
-    records = [
-        "ns-451.awsdns-56.com.",
-        "ns-1359.awsdns-41.org.",
-        "ns-1936.awsdns-50.co.uk.",
-        "ns-711.awsdns-24.net."
-    ]
-    ttl     = "172800"
+  zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
+  name    = "cds-snc.ca"
+  type    = "NS"
+  records = [
+    "ns-451.awsdns-56.com.",
+    "ns-1359.awsdns-41.org.",
+    "ns-1936.awsdns-50.co.uk.",
+    "ns-711.awsdns-24.net."
+  ]
+  ttl = "172800"
 
 }
 
 resource "aws_route53_record" "cds-snc-ca-SOA" {
-    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
-    name    = "cds-snc.ca"
-    type    = "SOA"
-    records = [
-        "ns-451.awsdns-56.com. awsdns-hostmaster.amazon.com. 1 7200 900 1209600 86400"
-    ]
-    ttl     = "900"
+  zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
+  name    = "cds-snc.ca"
+  type    = "SOA"
+  records = [
+    "ns-451.awsdns-56.com. awsdns-hostmaster.amazon.com. 1 7200 900 1209600 86400"
+  ]
+  ttl = "900"
 
 }
 
 # SES Domain ownership for IRCC account
 resource "aws_route53_record" "_amazonses-cds-snc-ca-TXT" {
-    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
-    name    = "_amazonses.cds-snc.ca"
-    type    = "TXT"
-    records = [
-        "K4JAa74M8w2vms1T3VFt4GTKY49WVxVAWXa85B2GGwg=",
-        "rMQZgwOueQecO9q4zjkRsVbPLzwcWWBc+QGXukgqADc="
-    ]
-    ttl     = "1800"
+  zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
+  name    = "_amazonses.cds-snc.ca"
+  type    = "TXT"
+  records = [
+    "K4JAa74M8w2vms1T3VFt4GTKY49WVxVAWXa85B2GGwg=",
+    "rMQZgwOueQecO9q4zjkRsVbPLzwcWWBc+QGXukgqADc="
+  ]
+  ttl = "1800"
 
 }
 
 resource "aws_route53_record" "_c77e17ef5146ea6fd6ba71f12813c9dc-cds-snc-ca-CNAME" {
-    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
-    name    = "_c77e17ef5146ea6fd6ba71f12813c9dc.cds-snc.ca"
-    type    = "CNAME"
-    records = [
-        "_e88f41d9935120137718f217c73c5389.tljzshvwok.acm-validations.aws."
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
+  name    = "_c77e17ef5146ea6fd6ba71f12813c9dc.cds-snc.ca"
+  type    = "CNAME"
+  records = [
+    "_e88f41d9935120137718f217c73c5389.tljzshvwok.acm-validations.aws."
+  ]
+  ttl = "300"
 
 }
 
 resource "aws_route53_record" "doxsxvr6k6upbjhr2ruxm4mqtrxiehuw-_domainkey-cds-snc-ca-CNAME" {
-    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
-    name    = "doxsxvr6k6upbjhr2ruxm4mqtrxiehuw._domainkey.cds-snc.ca"
-    type    = "CNAME"
-    records = [
-        "doxsxvr6k6upbjhr2ruxm4mqtrxiehuw.dkim.amazonses.com"
-    ]
-    ttl     = "1800"
+  zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
+  name    = "doxsxvr6k6upbjhr2ruxm4mqtrxiehuw._domainkey.cds-snc.ca"
+  type    = "CNAME"
+  records = [
+    "doxsxvr6k6upbjhr2ruxm4mqtrxiehuw.dkim.amazonses.com"
+  ]
+  ttl = "1800"
 
 }
 
 resource "aws_route53_record" "google-_domainkey-cds-snc-ca-TXT" {
-    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
-    name    = "google._domainkey.cds-snc.ca"
-    type    = "TXT"
-    records = [
-        "v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCtW1wKg+eFHEMnD0ZKPm8Bhoe6PzRTHOQbGnaBXpJllbUYqEKBpmz/u+zribZqjUfD8aFzZGt5SHGZAPXBUD0weiGuJFtuFrKDGQqknjxIaknMZrTXbre0bSw7lUUAb/b3qXvmQ6nZUOCaHvUJz09vZDGbKodhgj21hoRsLh4BeQIDAQAB"
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
+  name    = "google._domainkey.cds-snc.ca"
+  type    = "TXT"
+  records = [
+    "v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCtW1wKg+eFHEMnD0ZKPm8Bhoe6PzRTHOQbGnaBXpJllbUYqEKBpmz/u+zribZqjUfD8aFzZGt5SHGZAPXBUD0weiGuJFtuFrKDGQqknjxIaknMZrTXbre0bSw7lUUAb/b3qXvmQ6nZUOCaHvUJz09vZDGbKodhgj21hoRsLh4BeQIDAQAB"
+  ]
+  ttl = "300"
 
 }
 
 resource "aws_route53_record" "huaraq4dvcwl4dfjicrvjuyhod2zgyvz-_domainkey-cds-snc-ca-CNAME" {
-    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
-    name    = "huaraq4dvcwl4dfjicrvjuyhod2zgyvz._domainkey.cds-snc.ca"
-    type    = "CNAME"
-    records = [
-        "huaraq4dvcwl4dfjicrvjuyhod2zgyvz.dkim.amazonses.com"
-    ]
-    ttl     = "1800"
+  zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
+  name    = "huaraq4dvcwl4dfjicrvjuyhod2zgyvz._domainkey.cds-snc.ca"
+  type    = "CNAME"
+  records = [
+    "huaraq4dvcwl4dfjicrvjuyhod2zgyvz.dkim.amazonses.com"
+  ]
+  ttl = "1800"
 
 }
 
 resource "aws_route53_record" "scph0917-_domainkey-cds-snc-ca-TXT" {
-    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
-    name    = "scph0917._domainkey.cds-snc.ca"
-    type    = "TXT"
-    records = [
-        "v=DKIM1; k=rsa; h=sha256; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCrSPpQgQ4R+j3a/1PBCdnuw2Y0upCDmAaoNxkYFqhN35qLy1wA3Bba4abeTuKSxwAmxEN805YNPVp0FQ0Lv/B8ppsgyijv/riZvA/nHxWWoGCjofM+COlRjA+9+Us78hy1BPRKt+lgWMuW0t+UXrt055M3LXXOD9QH1IPvCHGifQIDAQAB"
-    ]
-    ttl     = "3600"
+  zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
+  name    = "scph0917._domainkey.cds-snc.ca"
+  type    = "TXT"
+  records = [
+    "v=DKIM1; k=rsa; h=sha256; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCrSPpQgQ4R+j3a/1PBCdnuw2Y0upCDmAaoNxkYFqhN35qLy1wA3Bba4abeTuKSxwAmxEN805YNPVp0FQ0Lv/B8ppsgyijv/riZvA/nHxWWoGCjofM+COlRjA+9+Us78hy1BPRKt+lgWMuW0t+UXrt055M3LXXOD9QH1IPvCHGifQIDAQAB"
+  ]
+  ttl = "3600"
 
 }
 
 resource "aws_route53_record" "vqrxkdrwqioudvaw3rrvwb2c6yre5673-_domainkey-cds-snc-ca-CNAME" {
-    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
-    name    = "vqrxkdrwqioudvaw3rrvwb2c6yre5673._domainkey.cds-snc.ca"
-    type    = "CNAME"
-    records = [
-        "vqrxkdrwqioudvaw3rrvwb2c6yre5673.dkim.amazonses.com"
-    ]
-    ttl     = "1800"
+  zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
+  name    = "vqrxkdrwqioudvaw3rrvwb2c6yre5673._domainkey.cds-snc.ca"
+  type    = "CNAME"
+  records = [
+    "vqrxkdrwqioudvaw3rrvwb2c6yre5673.dkim.amazonses.com"
+  ]
+  ttl = "1800"
 
 }
 
 # DKIM records for IRCC account
 resource "aws_route53_record" "jmdsjkhll6xcr45eceudowr3i5biw7m4-_domainkey-cds-snc-ca-CNAME" {
-    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
-    name    = "jmdsjkhll6xcr45eceudowr3i5biw7m4._domainkey.cds-snc.ca"
-    type    = "CNAME"
-    records = [
-        "jmdsjkhll6xcr45eceudowr3i5biw7m4.dkim.amazonses.com"
-    ]
-    ttl     = "1800"
+  zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
+  name    = "jmdsjkhll6xcr45eceudowr3i5biw7m4._domainkey.cds-snc.ca"
+  type    = "CNAME"
+  records = [
+    "jmdsjkhll6xcr45eceudowr3i5biw7m4.dkim.amazonses.com"
+  ]
+  ttl = "1800"
 
 }
 
 # DKIM records for IRCC account
 resource "aws_route53_record" "k64c4rhiqy2utki3pdklkmx4yddgfsvz-_domainkey-cds-snc-ca-CNAME" {
-    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
-    name    = "k64c4rhiqy2utki3pdklkmx4yddgfsvz._domainkey.cds-snc.ca"
-    type    = "CNAME"
-    records = [
-        "k64c4rhiqy2utki3pdklkmx4yddgfsvz.dkim.amazonses.com"
-    ]
-    ttl     = "1800"
+  zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
+  name    = "k64c4rhiqy2utki3pdklkmx4yddgfsvz._domainkey.cds-snc.ca"
+  type    = "CNAME"
+  records = [
+    "k64c4rhiqy2utki3pdklkmx4yddgfsvz.dkim.amazonses.com"
+  ]
+  ttl = "1800"
 
 }
 
 # DKIM records for IRCC account
 resource "aws_route53_record" "npuzzfyyhodvef3vwrj6qdu4tjqkw5ps-_domainkey-cds-snc-ca-CNAME" {
-    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
-    name    = "npuzzfyyhodvef3vwrj6qdu4tjqkw5ps._domainkey.cds-snc.ca"
-    type    = "CNAME"
-    records = [
-        "npuzzfyyhodvef3vwrj6qdu4tjqkw5ps.dkim.amazonses.com"
-    ]
-    ttl     = "1800"
+  zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
+  name    = "npuzzfyyhodvef3vwrj6qdu4tjqkw5ps._domainkey.cds-snc.ca"
+  type    = "CNAME"
+  records = [
+    "npuzzfyyhodvef3vwrj6qdu4tjqkw5ps.dkim.amazonses.com"
+  ]
+  ttl = "1800"
 
 }
 
 resource "aws_route53_record" "cds-snc-ca-TXT" {
-    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
-    name    = "cds-snc.ca"
-    type    = "TXT"
-    records = [
-        "MS=ms61032497",
-        "v=spf1 include:_spf.google.com include:email.freshdesk.com ~all"
-    ]
-    ttl     = "3600"
+  zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
+  name    = "cds-snc.ca"
+  type    = "TXT"
+  records = [
+    "MS=ms61032497",
+    "v=spf1 include:_spf.google.com include:email.freshdesk.com ~all"
+  ]
+  ttl = "3600"
 
 }
 
 # Freshdesk assistance portal
 resource "aws_route53_record" "assistance-cds-snc-ca-CNAME" {
-    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
-    name    = "assistance.cds-snc.ca"
-    type    = "CNAME"
-    records = [
-        "fdus-lb1-d59.freshdesk.com",
-    ]
-    ttl     = "3600"
+  zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
+  name    = "assistance.cds-snc.ca"
+  type    = "CNAME"
+  records = [
+    "fdus-lb1-d59.freshdesk.com",
+  ]
+  ttl = "3600"
 
 }
 
 resource "aws_route53_record" "assistance-cds-snc-ca-TXT" {
-    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
-    name    = "fdkey.assistance.cds-snc.ca"
-    type    = "TXT"
-    records = [
-        "b0207575c0143a0db62f4aa76fa88a80 "
-    ]
-    ttl     = "3600"
+  zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
+  name    = "fdkey.assistance.cds-snc.ca"
+  type    = "TXT"
+  records = [
+    "b0207575c0143a0db62f4aa76fa88a80 "
+  ]
+  ttl = "3600"
 
 }
 
 # Freshdesk Notify portal
 resource "aws_route53_record" "notification-assistance-cds-snc-ca-CNAME" {
-    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
-    name    = "notification.assistance.cds-snc.ca"
-    type    = "CNAME"
-    records = [
-        "fdus-lb1-d60.freshdesk.com",
-    ]
-    ttl     = "3600"
+  zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
+  name    = "notification.assistance.cds-snc.ca"
+  type    = "CNAME"
+  records = [
+    "fdus-lb1-d60.freshdesk.com",
+  ]
+  ttl = "3600"
 
 }
 
 resource "aws_route53_record" "notification-assistance-cds-snc-ca-TXT" {
-    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
-    name    = "fdkey.notification.assistance.cds-snc.ca"
-    type    = "TXT"
-    records = [
-        "b0207575c0143a0db62f4aa76fa88a80  "
-    ]
-    ttl     = "3600"
+  zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
+  name    = "fdkey.notification.assistance.cds-snc.ca"
+  type    = "TXT"
+  records = [
+    "b0207575c0143a0db62f4aa76fa88a80  "
+  ]
+  ttl = "3600"
 
 }
 
 # Freshdesk COVID Alert portal
 resource "aws_route53_record" "covid-assistance-cds-snc-ca-CNAME" {
-    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
-    name    = "covid.assistance.cds-snc.ca"
-    type    = "CNAME"
-    records = [
-        "fdus-lb27-d35.freshdesk.com",
-    ]
-    ttl     = "3600"
+  zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
+  name    = "covid.assistance.cds-snc.ca"
+  type    = "CNAME"
+  records = [
+    "fdus-lb27-d35.freshdesk.com",
+  ]
+  ttl = "3600"
 
 }
 
 resource "aws_route53_record" "covid-assistance-cds-snc-ca-TXT" {
-    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
-    name    = "fdkey.covid.assistance.cds-snc.ca"
-    type    = "TXT"
-    records = [
-        "b0207575c0143a0db62f4aa76fa88a80"
-    ]
-    ttl     = "3600"
+  zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
+  name    = "fdkey.covid.assistance.cds-snc.ca"
+  type    = "TXT"
+  records = [
+    "b0207575c0143a0db62f4aa76fa88a80"
+  ]
+  ttl = "3600"
 
 }
 
 # status page
 resource "aws_route53_record" "status-cds-snc-CNAME" {
-    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
-    name    = "status-statut.cds-snc.ca"
-    type    = "CNAME"
-    records = [
-        "domains.statuspal.io"
-    ]
-    ttl     = "1800"
+  zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
+  name    = "status-statut.cds-snc.ca"
+  type    = "CNAME"
+  records = [
+    "domains.statuspal.io"
+  ]
+  ttl = "1800"
 
 }

--- a/terraform/claim-tax-benefits.alpha.canada.ca.tf
+++ b/terraform/claim-tax-benefits.alpha.canada.ca.tf
@@ -1,29 +1,29 @@
 resource "aws_route53_record" "claim-tax-benefits-alpha-canada-ca-CNAME" {
-    zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
-    name    = "claim-tax-benefits.alpha.canada.ca"
-    type    = "CNAME"
-    records = [
-        "ctb-load-balancer-628344302.ca-central-1.elb.amazonaws.com"
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "claim-tax-benefits.alpha.canada.ca"
+  type    = "CNAME"
+  records = [
+    "ctb-load-balancer-628344302.ca-central-1.elb.amazonaws.com"
+  ]
+  ttl = "300"
 }
 
 resource "aws_route53_record" "reclamer-des-avantages-fiscaux-alpha-canada-ca-CNAME" {
-    zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
-    name    = "reclamer-des-avantages-fiscaux.alpha.canada.ca"
-    type    = "CNAME"
-    records = [
-        "ctb-load-balancer-628344302.ca-central-1.elb.amazonaws.com"
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "reclamer-des-avantages-fiscaux.alpha.canada.ca"
+  type    = "CNAME"
+  records = [
+    "ctb-load-balancer-628344302.ca-central-1.elb.amazonaws.com"
+  ]
+  ttl = "300"
 }
 
 resource "aws_route53_record" "claim-tax-benefits-alpha-canada-ca-aws-dns-CNAME" {
-    zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
-    name    = "_fdae793703c2c7c9c33369c921f965b4.claim-tax-benefits.alpha.canada.ca."
-    type    = "CNAME"
-    records = [
-        "_c2f4df6e286fd394d49a69aa49c86236.kirrbxfjtw.acm-validations.aws."
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "_fdae793703c2c7c9c33369c921f965b4.claim-tax-benefits.alpha.canada.ca."
+  type    = "CNAME"
+  records = [
+    "_c2f4df6e286fd394d49a69aa49c86236.kirrbxfjtw.acm-validations.aws."
+  ]
+  ttl = "300"
 }

--- a/terraform/covid-benefits.alpha.canada.ca.tf
+++ b/terraform/covid-benefits.alpha.canada.ca.tf
@@ -1,40 +1,40 @@
 resource "aws_route53_record" "covid-benefits-alpha-canada-ca-CNAME" {
-    zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
-    name    = "covid-benefits.alpha.canada.ca"
-    type    = "CNAME"
-    records = [
-        "espbdtscb19appservice.azurewebsites.net"
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "covid-benefits.alpha.canada.ca"
+  type    = "CNAME"
+  records = [
+    "espbdtscb19appservice.azurewebsites.net"
+  ]
+  ttl = "300"
 }
 
 resource "aws_route53_record" "covid-benefits-alpha-canada-ca-TXT" {
-    zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
-    name    = "asuid.covid-benefits.alpha.canada.ca"
-    type    = "TXT"
-    records = [
-        "5EC538F6E00B1480F70188C0174751749BEB5ACD0E4400FE3A85E48FA6CFC715"
-    ]
-    ttl     = "3600"
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "asuid.covid-benefits.alpha.canada.ca"
+  type    = "TXT"
+  records = [
+    "5EC538F6E00B1480F70188C0174751749BEB5ACD0E4400FE3A85E48FA6CFC715"
+  ]
+  ttl = "3600"
 
 }
 resource "aws_route53_record" "covid-prestations-alpha-canada-ca-CNAME" {
-    zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
-    name    = "covid-prestations.alpha.canada.ca"
-    type    = "CNAME"
-    records = [
-        "espbdtscb19appservice.azurewebsites.net"
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "covid-prestations.alpha.canada.ca"
+  type    = "CNAME"
+  records = [
+    "espbdtscb19appservice.azurewebsites.net"
+  ]
+  ttl = "300"
 }
 
 resource "aws_route53_record" "covid-prestations-alpha-canada-ca-TXT" {
-    zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
-    name    = "asuid.covid-prestations.alpha.canada.ca"
-    type    = "TXT"
-    records = [
-        "5EC538F6E00B1480F70188C0174751749BEB5ACD0E4400FE3A85E48FA6CFC715"
-    ]
-    ttl     = "3600"
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "asuid.covid-prestations.alpha.canada.ca"
+  type    = "TXT"
+  records = [
+    "5EC538F6E00B1480F70188C0174751749BEB5ACD0E4400FE3A85E48FA6CFC715"
+  ]
+  ttl = "3600"
 
 }

--- a/terraform/covid-notification.alpha.canada.ca.tf
+++ b/terraform/covid-notification.alpha.canada.ca.tf
@@ -1,12 +1,12 @@
 resource "aws_route53_record" "covid-notification-alpha-canada-ca-NS" {
-    zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
-    name    = "covid-notification.alpha.canada.ca"
-    type    = "NS"
-    records = [
-        "ns-1714.awsdns-22.co.uk",
-        "ns-93.awsdns-11.com",
-        "ns-1334.awsdns-38.org",
-        "ns-842.awsdns-41.net"
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "covid-notification.alpha.canada.ca"
+  type    = "NS"
+  records = [
+    "ns-1714.awsdns-22.co.uk",
+    "ns-93.awsdns-11.com",
+    "ns-1334.awsdns-38.org",
+    "ns-842.awsdns-41.net"
+  ]
+  ttl = "300"
 }

--- a/terraform/design.canada.ca.tf
+++ b/terraform/design.canada.ca.tf
@@ -5,7 +5,7 @@ resource "aws_route53_record" "design-alpha-canada-ca-A" {
   records = [
     "52.237.15.42"
   ]
-  ttl     = "300"
+  ttl = "300"
 }
 
 resource "aws_route53_record" "conception-alpha-canada-ca-A" {
@@ -15,5 +15,5 @@ resource "aws_route53_record" "conception-alpha-canada-ca-A" {
   records = [
     "52.237.15.42"
   ]
-  ttl     = "300"
+  ttl = "300"
 }

--- a/terraform/dmarc-reports.alpha.canada.ca.tf
+++ b/terraform/dmarc-reports.alpha.canada.ca.tf
@@ -1,10 +1,10 @@
 resource "aws_route53_record" "dmarc-report-alpha-canada-ca-A" {
-    zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
-    name    = "dmarc-reports.alpha.canada.ca"
-    type    = "CNAME"
-    records = [
-          "dmarc-report-api-brpuw6ogca-nn.a.run.app"
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "dmarc-reports.alpha.canada.ca"
+  type    = "CNAME"
+  records = [
+    "dmarc-report-api-brpuw6ogca-nn.a.run.app"
+  ]
+  ttl = "300"
 
 }

--- a/terraform/drupal-pilot.cer.alpha.canada.ca.tf
+++ b/terraform/drupal-pilot.cer.alpha.canada.ca.tf
@@ -5,5 +5,5 @@ resource "aws_route53_record" "drupal-pilot-cer-alpha-canada-ca-A" {
   records = [
     "52.237.15.42"
   ]
-  ttl     = "300"
+  ttl = "300"
 }

--- a/terraform/ebrief.cds-snc.ca.tf
+++ b/terraform/ebrief.cds-snc.ca.tf
@@ -1,10 +1,10 @@
 resource "aws_route53_record" "ebrief-cds-snc-ca-A" {
-    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
-    name    = "brief-bref.cds-snc.ca"
-    type    = "A"
-    records = [
-        "40.86.217.175"
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
+  name    = "brief-bref.cds-snc.ca"
+  type    = "A"
+  records = [
+    "40.86.217.175"
+  ]
+  ttl = "300"
 
 }

--- a/terraform/id-alpha-canada-ca.tf
+++ b/terraform/id-alpha-canada-ca.tf
@@ -1,13 +1,13 @@
 resource "aws_route53_record" "id-alpha-canada-ca-NS" {
-    zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
-    name    = "id.alpha.canada.ca"
-    type    = "NS"
-    records = [
-        "ns1-08.azure-dns.com",
-        "ns2-08.azure-dns.net",
-        "ns3-08.azure-dns.org",
-        "ns4-08.azure-dns.info"
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "id.alpha.canada.ca"
+  type    = "NS"
+  records = [
+    "ns1-08.azure-dns.com",
+    "ns2-08.azure-dns.net",
+    "ns3-08.azure-dns.org",
+    "ns4-08.azure-dns.info"
+  ]
+  ttl = "300"
 
 }

--- a/terraform/impact.cds-snc.ca.tf
+++ b/terraform/impact.cds-snc.ca.tf
@@ -1,21 +1,21 @@
 resource "aws_route53_record" "impact-cds-snc-ca-TXT" {
-    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
-    name    = "impact.cds-snc.ca"
-    type    = "TXT"
-    records = [
-        "v=spf1 include:mailgun.org ~all"
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
+  name    = "impact.cds-snc.ca"
+  type    = "TXT"
+  records = [
+    "v=spf1 include:mailgun.org ~all"
+  ]
+  ttl = "300"
 
 }
 
 resource "aws_route53_record" "mx-_domainkey-impact-cds-snc-ca-TXT" {
-    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
-    name    = "mx._domainkey.impact.cds-snc.ca"
-    type    = "TXT"
-    records = [
-        "k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDV8+/5WnTMuKleq2ZAMFvVpW9Cb/f/H5YFdcfN5IxiRZ5GqIMInMd+ZAr0lnEbEGMN49Xh/Zp/4306TwYtNpZDOsmExqTG49ptDURue7n63rJ8XFkawuZ9AGTgVfjLEnJtmk/b0idWEhvCg2HSH4l7J2bSr7QS5RiQ2nNq+0UxsQIDAQAB"
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
+  name    = "mx._domainkey.impact.cds-snc.ca"
+  type    = "TXT"
+  records = [
+    "k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDV8+/5WnTMuKleq2ZAMFvVpW9Cb/f/H5YFdcfN5IxiRZ5GqIMInMd+ZAr0lnEbEGMN49Xh/Zp/4306TwYtNpZDOsmExqTG49ptDURue7n63rJ8XFkawuZ9AGTgVfjLEnJtmk/b0idWEhvCg2HSH4l7J2bSr7QS5RiQ2nNq+0UxsQIDAQAB"
+  ]
+  ttl = "300"
 
 }

--- a/terraform/init.tf
+++ b/terraform/init.tf
@@ -8,7 +8,7 @@ terraform {
 }
 
 provider "aws" {
-  region  = "us-east-1"
+  region = "us-east-1"
 }
 
 terraform {

--- a/terraform/init.tf
+++ b/terraform/init.tf
@@ -1,6 +1,14 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 2.70"
+    }
+  }
+}
+
 provider "aws" {
   region  = "us-east-1"
-  version = "~> 2.70"
 }
 
 terraform {

--- a/terraform/mailgun.cds-snc.ca.tf
+++ b/terraform/mailgun.cds-snc.ca.tf
@@ -1,21 +1,21 @@
 resource "aws_route53_record" "mailgun-cds-snc-ca-TXT" {
-    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
-    name    = "mailgun.cds-snc.ca"
-    type    = "TXT"
-    records = [
-        "v=spf1 include:mailgun.org ~all"
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
+  name    = "mailgun.cds-snc.ca"
+  type    = "TXT"
+  records = [
+    "v=spf1 include:mailgun.org ~all"
+  ]
+  ttl = "300"
 
 }
 
 resource "aws_route53_record" "pic-_domainkey-mailgun-cds-snc-ca-TXT" {
-    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
-    name    = "pic._domainkey.mailgun.cds-snc.ca"
-    type    = "TXT"
-    records = [
-        "k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDqd5+hPaqvz/V7CKwQCIKvvV4N0slJV/R7KfF91VS+G8RLJisWpWl80ixKVm2RuGYJFJqgzLGwdd8uHL5v+HiJK5fi5+unr/1zLBtrg9prZntFxRMm2vp839LV6kYGChKaL3dIhRAEEDt1iU4j45SVgOQc37Dgyf7GAdVjHp5EVQIDAQAB"
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
+  name    = "pic._domainkey.mailgun.cds-snc.ca"
+  type    = "TXT"
+  records = [
+    "k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDqd5+hPaqvz/V7CKwQCIKvvV4N0slJV/R7KfF91VS+G8RLJisWpWl80ixKVm2RuGYJFJqgzLGwdd8uHL5v+HiJK5fi5+unr/1zLBtrg9prZntFxRMm2vp839LV6kYGChKaL3dIhRAEEDt1iU4j45SVgOQc37Dgyf7GAdVjHp5EVQIDAQAB"
+  ]
+  ttl = "300"
 
 }

--- a/terraform/notification.alpha.canada.ca.tf
+++ b/terraform/notification.alpha.canada.ca.tf
@@ -1,167 +1,167 @@
 resource "aws_route53_record" "notification-alpha-canada-ca-ALIAS" {
-    zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
-    name    = "notification.alpha.canada.ca"
-    type    = "A"
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "notification.alpha.canada.ca"
+  type    = "A"
 
-    alias {
-        name                   = local.notification_alb
-        zone_id                = local.notification_zone_id
-        evaluate_target_health = true
-    }
+  alias {
+    name                   = local.notification_alb
+    zone_id                = local.notification_zone_id
+    evaluate_target_health = true
+  }
 }
 
 resource "aws_route53_record" "api-notification-alpha-canada-ca-A" {
-    zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
-    name    = "api.notification.alpha.canada.ca"
-    type    = "CNAME"
-    records = [
-        local.notification_alb
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "api.notification.alpha.canada.ca"
+  type    = "CNAME"
+  records = [
+    local.notification_alb
+  ]
+  ttl = "300"
 
 }
 
 resource "aws_route53_record" "document-notification-alpha-canada-ca-A" {
-    zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
-    name    = "document.notification.alpha.canada.ca"
-    type    = "CNAME"
-    records = [
-        local.notification_alb
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "document.notification.alpha.canada.ca"
+  type    = "CNAME"
+  records = [
+    local.notification_alb
+  ]
+  ttl = "300"
 
 }
 
 resource "aws_route53_record" "api-document-notification-alpha-canada-ca-A" {
-    zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
-    name    = "api.document.notification.alpha.canada.ca"
-    type    = "CNAME"
-    records = [
-        local.notification_alb
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "api.document.notification.alpha.canada.ca"
+  type    = "CNAME"
+  records = [
+    local.notification_alb
+  ]
+  ttl = "300"
 
 }
 
 resource "aws_route53_record" "api-document-notification-alpha-canada-ca-ACM-cname" {
-    zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
-    name    = "_01d16c796a05d4f42e7919c19dde8838.api.document.notification.alpha.canada.ca"
-    type    = "CNAME"
-    records = [
-        "_c8c050c1144e4dec5e36ccdb61362575.zbkrxsrfvj.acm-validations.aws."
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "_01d16c796a05d4f42e7919c19dde8838.api.document.notification.alpha.canada.ca"
+  type    = "CNAME"
+  records = [
+    "_c8c050c1144e4dec5e36ccdb61362575.zbkrxsrfvj.acm-validations.aws."
+  ]
+  ttl = "300"
 
 }
 
 resource "aws_route53_record" "notification-alpha-canada-ca-ACM-cname" {
-    zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
-    name    = "_73714e81c7f7350e34a22f64fc6892bf.notification.alpha.canada.ca"
-    type    = "CNAME"
-    records = [
-        "_d6f462435ba01046692930d7774565d4.nhqijqilxf.acm-validations.aws."
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "_73714e81c7f7350e34a22f64fc6892bf.notification.alpha.canada.ca"
+  type    = "CNAME"
+  records = [
+    "_d6f462435ba01046692930d7774565d4.nhqijqilxf.acm-validations.aws."
+  ]
+  ttl = "300"
 
 }
 
 
 resource "aws_route53_record" "amazonses-notification-alpha-canada-ca-TXT" {
-    zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
-    name    = "_amazonses.notification.alpha.canada.ca"
-    type    = "TXT"
-    records = [
-        "F+pOEXNcTKyLOfjv6vakPH7L7BDJyJWk0z3X4lMEpJk="
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "_amazonses.notification.alpha.canada.ca"
+  type    = "TXT"
+  records = [
+    "F+pOEXNcTKyLOfjv6vakPH7L7BDJyJWk0z3X4lMEpJk="
+  ]
+  ttl = "300"
 
 }
 
 resource "aws_route53_record" "dkim1-notification-alpha-canada-ca-CNAME" {
-    zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
-    name    = "vqaz5umlocfrnmfbflvju6qduqut7i5h._domainkey.notification.alpha.canada.ca"
-    type    = "CNAME"
-    records = [
-        "vqaz5umlocfrnmfbflvju6qduqut7i5h.dkim.amazonses.com"
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "vqaz5umlocfrnmfbflvju6qduqut7i5h._domainkey.notification.alpha.canada.ca"
+  type    = "CNAME"
+  records = [
+    "vqaz5umlocfrnmfbflvju6qduqut7i5h.dkim.amazonses.com"
+  ]
+  ttl = "300"
 
 }
 
 resource "aws_route53_record" "dkim2-notification-alpha-canada-ca-CNAME" {
-    zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
-    name    = "hofufbbtcrcvxie3vngnqb6ew3p4qjst._domainkey.notification.alpha.canada.ca"
-    type    = "CNAME"
-    records = [
-        "hofufbbtcrcvxie3vngnqb6ew3p4qjst.dkim.amazonses.com"
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "hofufbbtcrcvxie3vngnqb6ew3p4qjst._domainkey.notification.alpha.canada.ca"
+  type    = "CNAME"
+  records = [
+    "hofufbbtcrcvxie3vngnqb6ew3p4qjst.dkim.amazonses.com"
+  ]
+  ttl = "300"
 
 }
 
 resource "aws_route53_record" "dkim3-notification-alpha-canada-ca-CNAME" {
-    zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
-    name    = "t2ihvmsa65nqcjuemxykbsivxbqhecg7._domainkey.notification.alpha.canada.ca"
-    type    = "CNAME"
-    records = [
-        "t2ihvmsa65nqcjuemxykbsivxbqhecg7.dkim.amazonses.com"
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "t2ihvmsa65nqcjuemxykbsivxbqhecg7._domainkey.notification.alpha.canada.ca"
+  type    = "CNAME"
+  records = [
+    "t2ihvmsa65nqcjuemxykbsivxbqhecg7.dkim.amazonses.com"
+  ]
+  ttl = "300"
 
 }
 
 resource "aws_route53_record" "notification-alpha-canada-ca-SPF" {
-    zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
-    name    = "notification.alpha.canada.ca"
-    type    = "TXT"
-    records = [
-        "v=spf1 include:amazonses.com -all"
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "notification.alpha.canada.ca"
+  type    = "TXT"
+  records = [
+    "v=spf1 include:amazonses.com -all"
+  ]
+  ttl = "300"
 
 }
 
 resource "aws_route53_record" "notification-alpha-canada-ca-DMARC" {
-    zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
-    name    = "_dmarc.notification.alpha.canada.ca"
-    type    = "TXT"
-    records = [
-        "v=DMARC1; p=reject; sp=reject; pct=100; rua=mailto:dmarc@cyber.gc.ca"
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "_dmarc.notification.alpha.canada.ca"
+  type    = "TXT"
+  records = [
+    "v=DMARC1; p=reject; sp=reject; pct=100; rua=mailto:dmarc@cyber.gc.ca"
+  ]
+  ttl = "300"
 
 }
 
 resource "aws_route53_record" "m-notification-alpha-canada-ca-NS" {
-    zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
-    name    = "m.notification.alpha.canada.ca"
-    type    = "NS"
-    records = [
-        "ns-506.awsdns-63.com",
-        "ns-865.awsdns-44.net",
-        "ns-2019.awsdns-60.co.uk",
-        "ns-1201.awsdns-22.org"
-    ]
-    ttl     = "30"
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "m.notification.alpha.canada.ca"
+  type    = "NS"
+  records = [
+    "ns-506.awsdns-63.com",
+    "ns-865.awsdns-44.net",
+    "ns-2019.awsdns-60.co.uk",
+    "ns-1201.awsdns-22.org"
+  ]
+  ttl = "30"
 
 }
 
 resource "aws_route53_record" "pbmm-notification-alpha-canada-ca-ACM-cname" {
-    zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
-    name    = "_c04744a360b120e8b7431728784deab4.notification.alpha.canada.ca"
-    type    = "CNAME"
-    records = [
-        "_70060f7d839ca6659556126a3224d85b.wggjkglgrm.acm-validations.aws."
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "_c04744a360b120e8b7431728784deab4.notification.alpha.canada.ca"
+  type    = "CNAME"
+  records = [
+    "_70060f7d839ca6659556126a3224d85b.wggjkglgrm.acm-validations.aws."
+  ]
+  ttl = "300"
 }
 
 resource "aws_route53_record" "pbmm-document-notification-alpha-canada-ca-ACM-cname" {
-    zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
-    name    = "_35e023fab08debc90c4312ec398d5458.document.notification.alpha.canada.ca"
-    type    = "CNAME"
-    records = [
-        "_851a551fec0bff7d31f336583a3138e7.wggjkglgrm.acm-validations.aws."
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "_35e023fab08debc90c4312ec398d5458.document.notification.alpha.canada.ca"
+  type    = "CNAME"
+  records = [
+    "_851a551fec0bff7d31f336583a3138e7.wggjkglgrm.acm-validations.aws."
+  ]
+  ttl = "300"
 }

--- a/terraform/notification.canada.ca-zone.tf
+++ b/terraform/notification.canada.ca-zone.tf
@@ -8,7 +8,7 @@ resource "aws_route53_zone" "notification-canada-ca-public" {
 }
 
 output "notification-canada-ca-ns" {
-  value= "${aws_route53_zone.notification-canada-ca-public.name_servers}"
+  value = aws_route53_zone.notification-canada-ca-public.name_servers
 }
 
 locals {

--- a/terraform/notification.canada.ca-zone.tf
+++ b/terraform/notification.canada.ca-zone.tf
@@ -1,10 +1,10 @@
 resource "aws_route53_zone" "notification-canada-ca-public" {
-    name       = "notification.canada.ca"
-    comment    = ""
+  name    = "notification.canada.ca"
+  comment = ""
 
-    tags = {
-        Project = "dns"
-    }
+  tags = {
+    Project = "dns"
+  }
 }
 
 output "notification-canada-ca-ns" {
@@ -12,211 +12,211 @@ output "notification-canada-ca-ns" {
 }
 
 locals {
-    notification_alb = "notification-production-alb-1685085140.ca-central-1.elb.amazonaws.com"
-    notification_zone_id = "ZQSVJUPU6J1EY"
+  notification_alb     = "notification-production-alb-1685085140.ca-central-1.elb.amazonaws.com"
+  notification_zone_id = "ZQSVJUPU6J1EY"
 }
 
 resource "aws_route53_record" "notification-canada-ca-ALIAS" {
-    zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
-    name    = "notification.canada.ca"
-    type    = "A"
+  zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
+  name    = "notification.canada.ca"
+  type    = "A"
 
-    alias {
-        name                   = local.notification_alb
-        zone_id                = local.notification_zone_id
-        evaluate_target_health = true
-    }
+  alias {
+    name                   = local.notification_alb
+    zone_id                = local.notification_zone_id
+    evaluate_target_health = true
+  }
 }
 
 resource "aws_route53_record" "api-notification-canada-ca-A" {
-    zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
-    name    = "api.notification.canada.ca"
-    type    = "CNAME"
-    records = [
-        local.notification_alb
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
+  name    = "api.notification.canada.ca"
+  type    = "CNAME"
+  records = [
+    local.notification_alb
+  ]
+  ttl = "300"
 }
 
 resource "aws_route53_record" "document-notification-canada-ca-A" {
-    zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
-    name    = "document.notification.canada.ca"
-    type    = "CNAME"
-    records = [
-        local.notification_alb
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
+  name    = "document.notification.canada.ca"
+  type    = "CNAME"
+  records = [
+    local.notification_alb
+  ]
+  ttl = "300"
 }
 
 resource "aws_route53_record" "api-document-notification-canada-ca-A" {
-    zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
-    name    = "api.document.notification.canada.ca"
-    type    = "CNAME"
-    records = [
-        local.notification_alb
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
+  name    = "api.document.notification.canada.ca"
+  type    = "CNAME"
+  records = [
+    local.notification_alb
+  ]
+  ttl = "300"
 }
 
 resource "aws_route53_record" "www-notification-canada-ca-CNAME" {
-    zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
-    name    = "www.notification.canada.ca"
-    type    = "CNAME"
-    records = [
-        local.notification_alb
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
+  name    = "www.notification.canada.ca"
+  type    = "CNAME"
+  records = [
+    local.notification_alb
+  ]
+  ttl = "300"
 }
 
 resource "aws_route53_record" "documentation-notification-canada-ca-CNAME" {
-    zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
-    name    = "documentation.notification.canada.ca"
-    type    = "CNAME"
-    records = [
-        local.notification_alb
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
+  name    = "documentation.notification.canada.ca"
+  type    = "CNAME"
+  records = [
+    local.notification_alb
+  ]
+  ttl = "300"
 }
 
 resource "aws_route53_record" "doc-notification-canada-ca-CNAME" {
-    zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
-    name    = "doc.notification.canada.ca"
-    type    = "CNAME"
-    records = [
-        local.notification_alb
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
+  name    = "doc.notification.canada.ca"
+  type    = "CNAME"
+  records = [
+    local.notification_alb
+  ]
+  ttl = "300"
 }
 
 resource "aws_route53_record" "notification-canada-ca-ACM-cname" {
-    zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
-    name    = "_2115a5004ab7895234c60254e152046b.notification.canada.ca"
-    type    = "CNAME"
-    records = [
-        "_aaacd89cd470de0970c70c7ab1b7d4d5.wggjkglgrm.acm-validations.aws."
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
+  name    = "_2115a5004ab7895234c60254e152046b.notification.canada.ca"
+  type    = "CNAME"
+  records = [
+    "_aaacd89cd470de0970c70c7ab1b7d4d5.wggjkglgrm.acm-validations.aws."
+  ]
+  ttl = "300"
 }
 
 resource "aws_route53_record" "document-notification-canada-ca-ACM-cname" {
-    zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
-    name    = "_db43d1cf891afd4671fb913d18ef0a0e.document.notification.canada.ca"
-    type    = "CNAME"
-    records = [
-        "_130ea19fa1fdd9e59b7632fbac0d7e00.wggjkglgrm.acm-validations.aws."
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
+  name    = "_db43d1cf891afd4671fb913d18ef0a0e.document.notification.canada.ca"
+  type    = "CNAME"
+  records = [
+    "_130ea19fa1fdd9e59b7632fbac0d7e00.wggjkglgrm.acm-validations.aws."
+  ]
+  ttl = "300"
 }
 
 resource "aws_route53_record" "assets-notification-canada-ca-ACM-cname" {
-    zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
-    name    = "_4e30c74d7459e0d63bdcdaac7a57fdcf.assets.notification.canada.ca"
-    type    = "CNAME"
-    records = [
-        "_2da9b84f7e094fd64c8930cffe8d9842.wggjkglgrm.acm-validations.aws."
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
+  name    = "_4e30c74d7459e0d63bdcdaac7a57fdcf.assets.notification.canada.ca"
+  type    = "CNAME"
+  records = [
+    "_2da9b84f7e094fd64c8930cffe8d9842.wggjkglgrm.acm-validations.aws."
+  ]
+  ttl = "300"
 }
 
 resource "aws_route53_record" "assets-notification-canada-ca-cname" {
-    zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
-    name    = "assets.notification.canada.ca"
-    type    = "CNAME"
-    records = [
-        "d1spq0ojswv1dj.cloudfront.net"
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
+  name    = "assets.notification.canada.ca"
+  type    = "CNAME"
+  records = [
+    "d1spq0ojswv1dj.cloudfront.net"
+  ]
+  ttl = "300"
 }
 
 resource "aws_route53_record" "dkim1-notification-canada-ca-CNAME" {
-    zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
-    name    = "wrs6wsp65k764hnaouax5t66vfqrbrst._domainkey.notification.canada.ca"
-    type    = "CNAME"
-    records = [
-        "wrs6wsp65k764hnaouax5t66vfqrbrst.dkim.amazonses.com"
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
+  name    = "wrs6wsp65k764hnaouax5t66vfqrbrst._domainkey.notification.canada.ca"
+  type    = "CNAME"
+  records = [
+    "wrs6wsp65k764hnaouax5t66vfqrbrst.dkim.amazonses.com"
+  ]
+  ttl = "300"
 }
 
 resource "aws_route53_record" "dkim2-notification-canada-ca-CNAME" {
-    zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
-    name    = "wrtaqi2wdu42zqjzyf3ikn46kzos4f76._domainkey.notification.canada.ca"
-    type    = "CNAME"
-    records = [
-        "wrtaqi2wdu42zqjzyf3ikn46kzos4f76.dkim.amazonses.com"
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
+  name    = "wrtaqi2wdu42zqjzyf3ikn46kzos4f76._domainkey.notification.canada.ca"
+  type    = "CNAME"
+  records = [
+    "wrtaqi2wdu42zqjzyf3ikn46kzos4f76.dkim.amazonses.com"
+  ]
+  ttl = "300"
 }
 
 resource "aws_route53_record" "dkim3-notification-canada-ca-CNAME" {
-    zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
-    name    = "h2d5mnabqwlnowww7rkgpoagtrxt7d4z._domainkey.notification.canada.ca"
-    type    = "CNAME"
-    records = [
-        "h2d5mnabqwlnowww7rkgpoagtrxt7d4z.dkim.amazonses.com"
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
+  name    = "h2d5mnabqwlnowww7rkgpoagtrxt7d4z._domainkey.notification.canada.ca"
+  type    = "CNAME"
+  records = [
+    "h2d5mnabqwlnowww7rkgpoagtrxt7d4z.dkim.amazonses.com"
+  ]
+  ttl = "300"
 }
 
 resource "aws_route53_record" "notification-canada-ca-SPF" {
-    zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
-    name    = "notification.canada.ca"
-    type    = "TXT"
-    records = [
-        "v=spf1 include:amazonses.com -all"
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
+  name    = "notification.canada.ca"
+  type    = "TXT"
+  records = [
+    "v=spf1 include:amazonses.com -all"
+  ]
+  ttl = "300"
 }
 
 resource "aws_route53_record" "notification-canada-ca-DMARC" {
-    zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
-    name    = "_dmarc.notification.canada.ca"
-    type    = "TXT"
-    records = [
-        "v=DMARC1; p=reject; sp=reject; pct=100; rua=mailto:dmarc@cyber.gc.ca"
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
+  name    = "_dmarc.notification.canada.ca"
+  type    = "TXT"
+  records = [
+    "v=DMARC1; p=reject; sp=reject; pct=100; rua=mailto:dmarc@cyber.gc.ca"
+  ]
+  ttl = "300"
 }
 
 resource "aws_route53_record" "amazonses-notification-canada-ca-TXT" {
-    zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
-    name    = "_amazonses.notification.canada.ca"
-    type    = "TXT"
-    records = [
-        "Ohfl/Syh3ZT5U/7IKELTCXIRaqI42ZJiw0HiUQoCHww="
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
+  name    = "_amazonses.notification.canada.ca"
+  type    = "TXT"
+  records = [
+    "Ohfl/Syh3ZT5U/7IKELTCXIRaqI42ZJiw0HiUQoCHww="
+  ]
+  ttl = "300"
 }
 
 resource "aws_route53_record" "amazonses-mail-from-notification-canada-ca-TXT" {
-    zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
-    name    = "bounce.notification.canada.ca"
-    type    = "TXT"
-    records = [
-        "v=spf1 include:amazonses.com -all"
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
+  name    = "bounce.notification.canada.ca"
+  type    = "TXT"
+  records = [
+    "v=spf1 include:amazonses.com -all"
+  ]
+  ttl = "300"
 }
 
 resource "aws_route53_record" "amazonses-mail-from-notification-canada-ca-MX" {
-    zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
-    name    = "bounce.notification.canada.ca"
-    type    = "MX"
-    records = [
-        "10 feedback-smtp.ca-central-1.amazonses.com"
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
+  name    = "bounce.notification.canada.ca"
+  type    = "MX"
+  records = [
+    "10 feedback-smtp.ca-central-1.amazonses.com"
+  ]
+  ttl = "300"
 }
 
 resource "aws_route53_record" "smtp-notification-canada-ca-NS" {
-    zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
-    name    = "smtp.notification.canada.ca"
-    type    = "NS"
-    records = [
-        "ns-125.awsdns-15.com",
-        "ns-1193.awsdns-21.org",
-        "ns-1879.awsdns-42.co.uk",
-        "ns-606.awsdns-11.net"
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
+  name    = "smtp.notification.canada.ca"
+  type    = "NS"
+  records = [
+    "ns-125.awsdns-15.com",
+    "ns-1193.awsdns-21.org",
+    "ns-1879.awsdns-42.co.uk",
+    "ns-606.awsdns-11.net"
+  ]
+  ttl = "300"
 }

--- a/terraform/nrcan-energuide-poc.cds-snc.ca.tf
+++ b/terraform/nrcan-energuide-poc.cds-snc.ca.tf
@@ -1,10 +1,10 @@
 resource "aws_route53_record" "nrcan-energuide-poc-cds-snc-ca-A" {
-    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
-    name    = "nrcan-energuide-poc.cds-snc.ca"
-    type    = "A"
-    records = [
-        "52.237.20.235"
-    ]
-    ttl     = "60"
+  zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
+  name    = "nrcan-energuide-poc.cds-snc.ca"
+  type    = "A"
+  records = [
+    "52.237.20.235"
+  ]
+  ttl = "60"
 
 }

--- a/terraform/nrcanapi.cds-snc.ca.tf
+++ b/terraform/nrcanapi.cds-snc.ca.tf
@@ -1,10 +1,10 @@
 resource "aws_route53_record" "nrcanapi-cds-snc-ca-A" {
-    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
-    name    = "nrcanapi.cds-snc.ca"
-    type    = "A"
-    records = [
-        "52.237.20.235"
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
+  name    = "nrcanapi.cds-snc.ca"
+  type    = "A"
+  records = [
+    "52.237.20.235"
+  ]
+  ttl = "300"
 
 }

--- a/terraform/opencall-appelouvert-alpha-canada.ca.tf
+++ b/terraform/opencall-appelouvert-alpha-canada.ca.tf
@@ -1,21 +1,21 @@
 resource "aws_route53_record" "opencall-appelouvert-alpha-canada-ca-A" {
-    zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
-    name    = "opencall-appelouvert.alpha.canada.ca"
-    type    = "A"
-    alias {
-        name                   = "d3ltcddksvc3w1.cloudfront.net"
-        zone_id                = "Z2FDTNDATAQYW2"
-        evaluate_target_health = true
-    }
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "opencall-appelouvert.alpha.canada.ca"
+  type    = "A"
+  alias {
+    name                   = "d3ltcddksvc3w1.cloudfront.net"
+    zone_id                = "Z2FDTNDATAQYW2"
+    evaluate_target_health = true
+  }
 }
 
 resource "aws_route53_record" "_cb979fcab2fc2fecda36a5b4a82f5aa6-opencall-appelouvert-alpha-canada-ca-CNAME" {
-    zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
-    name    = "_cb979fcab2fc2fecda36a5b4a82f5aa6.opencall-appelouvert.alpha.canada.ca."
-    type    = "CNAME"
-    records = [
-        "_02898b792f1aefc50c4153cd49a979c8.wggjkglgrm.acm-validations.aws."
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "_cb979fcab2fc2fecda36a5b4a82f5aa6.opencall-appelouvert.alpha.canada.ca."
+  type    = "CNAME"
+  records = [
+    "_02898b792f1aefc50c4153cd49a979c8.wggjkglgrm.acm-validations.aws."
+  ]
+  ttl = "300"
 
 }

--- a/terraform/performance.alpha.canada.ca.tf
+++ b/terraform/performance.alpha.canada.ca.tf
@@ -5,7 +5,7 @@ resource "aws_route53_record" "performance-alpha-canada-ca-A" {
   records = [
     "52.237.15.42"
   ]
-  ttl     = "300"
+  ttl = "300"
 }
 
 resource "aws_route53_record" "rendement-alpha-canada-ca-A" {
@@ -15,5 +15,5 @@ resource "aws_route53_record" "rendement-alpha-canada-ca-A" {
   records = [
     "52.237.15.42"
   ]
-  ttl     = "300"
+  ttl = "300"
 }

--- a/terraform/platform.canada.ca.tf
+++ b/terraform/platform.canada.ca.tf
@@ -1,10 +1,10 @@
 resource "aws_route53_zone" "platform-canada-ca-public" {
-    name       = "platform.canada.ca"
-    comment    = ""
+  name    = "platform.canada.ca"
+  comment = ""
 
-    tags = {
-        Project = "dns"
-    }
+  tags = {
+    Project = "dns"
+  }
 }
 
 output "platform-canada-ca-ns" {
@@ -12,12 +12,12 @@ output "platform-canada-ca-ns" {
 }
 
 resource "aws_route53_zone" "plateforme-canada-ca-public" {
-    name       = "plateforme.canada.ca"
-    comment    = ""
+  name    = "plateforme.canada.ca"
+  comment = ""
 
-    tags = {
-        Project = "dns"
-    }
+  tags = {
+    Project = "dns"
+  }
 }
 
 output "plateforme-canada-ca-ns" {

--- a/terraform/platform.canada.ca.tf
+++ b/terraform/platform.canada.ca.tf
@@ -8,7 +8,7 @@ resource "aws_route53_zone" "platform-canada-ca-public" {
 }
 
 output "platform-canada-ca-ns" {
-  value="${aws_route53_zone.platform-canada-ca-public.name_servers}"
+  value = aws_route53_zone.platform-canada-ca-public.name_servers
 }
 
 resource "aws_route53_zone" "plateforme-canada-ca-public" {
@@ -21,5 +21,5 @@ resource "aws_route53_zone" "plateforme-canada-ca-public" {
 }
 
 output "plateforme-canada-ca-ns" {
-  value="${aws_route53_zone.plateforme-canada-ca-public.name_servers}"
+  value = aws_route53_zone.plateforme-canada-ca-public.name_servers
 }

--- a/terraform/privacy-statements.alpha.canada.ca.tf
+++ b/terraform/privacy-statements.alpha.canada.ca.tf
@@ -1,19 +1,19 @@
 resource "aws_route53_record" "privacy-statements-cds-alpha-canada-ca-CNAME" {
-    zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
-    name    = "privacy-statements.cds.alpha.canada.ca"
-    type    = "CNAME"
-    records = [
-        "radiant-damselfly-fxzk8vc81qdj2jzmuog6ncda.herokudns.com"
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "privacy-statements.cds.alpha.canada.ca"
+  type    = "CNAME"
+  records = [
+    "radiant-damselfly-fxzk8vc81qdj2jzmuog6ncda.herokudns.com"
+  ]
+  ttl = "300"
 }
 
 resource "aws_route53_record" "avis-confidentialite-snc-alpha-canada-ca-CNAME" {
-    zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
-    name    = "avis-confidentialite.snc.alpha.canada.ca"
-    type    = "CNAME"
-    records = [
-        "behavioural-scallop-nlrxwf5edg8eivh9qeu0ai9p.herokudns.com"
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "avis-confidentialite.snc.alpha.canada.ca"
+  type    = "CNAME"
+  records = [
+    "behavioural-scallop-nlrxwf5edg8eivh9qeu0ai9p.herokudns.com"
+  ]
+  ttl = "300"
 }

--- a/terraform/pulse-alpha-canada-ca.tf
+++ b/terraform/pulse-alpha-canada-ca.tf
@@ -5,7 +5,7 @@ resource "aws_route53_record" "pulse-alpha-canada-ca-A" {
   records = [
     "34.95.5.243"
   ]
-  ttl     = "300"
+  ttl = "300"
 }
 
 resource "aws_route53_record" "pouls-alpha-canada-ca-A" {
@@ -15,5 +15,5 @@ resource "aws_route53_record" "pouls-alpha-canada-ca-A" {
   records = [
     "34.95.5.243"
   ]
-  ttl     = "300"
+  ttl = "300"
 }

--- a/terraform/report-a-scam.cds-snc.ca.tf
+++ b/terraform/report-a-scam.cds-snc.ca.tf
@@ -1,19 +1,19 @@
 resource "aws_route53_record" "report-a-scam-cds-snc-ca-CNAME" {
-    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
-    name    = "report-a-scam.cds-snc.ca"
-    type    = "CNAME"
-    records = [
-        "report-a-scam.azurewebsites.net"
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
+  name    = "report-a-scam.cds-snc.ca"
+  type    = "CNAME"
+  records = [
+    "report-a-scam.azurewebsites.net"
+  ]
+  ttl = "300"
 }
 
 resource "aws_route53_record" "signalez-un-crime-informatique-cds-snc-ca-CNAME" {
-    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
-    name    = "signalez-un-crime-informatique.cds-snc.ca"
-    type    = "CNAME"
-    records = [
-        "report-a-scam.azurewebsites.net"
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
+  name    = "signalez-un-crime-informatique.cds-snc.ca"
+  type    = "CNAME"
+  records = [
+    "report-a-scam.azurewebsites.net"
+  ]
+  ttl = "300"
 }

--- a/terraform/rescheduler-dev.cds-snc.ca.tf
+++ b/terraform/rescheduler-dev.cds-snc.ca.tf
@@ -1,44 +1,44 @@
 resource "aws_route53_record" "rescheduler-dev-cds-snc-ca-CNAME" {
-    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
-    name    = "rescheduler-dev.cds-snc.ca"
-    type    = "CNAME"
-    records = [
-        "d1z7870hb8y3pu.cloudfront.net"
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
+  name    = "rescheduler-dev.cds-snc.ca"
+  type    = "CNAME"
+  records = [
+    "d1z7870hb8y3pu.cloudfront.net"
+  ]
+  ttl = "300"
 
 }
 
 resource "aws_route53_record" "wildcard-rescheduler-dev-cds-snc-ca-CNAME" {
-    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
-    name    = "*.rescheduler-dev.cds-snc.ca"
-    type    = "CNAME"
-    records = [
-        "d1z7870hb8y3pu.cloudfront.net"
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
+  name    = "*.rescheduler-dev.cds-snc.ca"
+  type    = "CNAME"
+  records = [
+    "d1z7870hb8y3pu.cloudfront.net"
+  ]
+  ttl = "300"
 
 }
 
 resource "aws_route53_record" "_6ad6e4d2289f5b17d4761e6a95fe53ee-rescheduler-dev-cds-snc-ca-CNAME" {
-    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
-    name    = "_6ad6e4d2289f5b17d4761e6a95fe53ee.rescheduler-dev.cds-snc.ca"
-    type    = "CNAME"
-    records = [
-        "_9f7db3b2eec58e7b8e1ca0f84b26c715.tljzshvwok.acm-validations.aws."
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
+  name    = "_6ad6e4d2289f5b17d4761e6a95fe53ee.rescheduler-dev.cds-snc.ca"
+  type    = "CNAME"
+  records = [
+    "_9f7db3b2eec58e7b8e1ca0f84b26c715.tljzshvwok.acm-validations.aws."
+  ]
+  ttl = "300"
 
 }
 
 resource "aws_route53_record" "_acme-challenge-rescheduler-dev-cds-snc-ca-TXT" {
-    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
-    name    = "_acme-challenge.rescheduler-dev.cds-snc.ca"
-    type    = "TXT"
-    records = [
-        "XRweum4xSV_4iimY2rJCX-6lnZDc9zAgrVDL0vWm5Zw", 
-        "6id1gvm9xLfzCkiGyZTypCPVZB7bdQMuNIp3DjCqlSc"
-    ]
-    ttl     = "60"
+  zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
+  name    = "_acme-challenge.rescheduler-dev.cds-snc.ca"
+  type    = "TXT"
+  records = [
+    "XRweum4xSV_4iimY2rJCX-6lnZDc9zAgrVDL0vWm5Zw",
+    "6id1gvm9xLfzCkiGyZTypCPVZB7bdQMuNIp3DjCqlSc"
+  ]
+  ttl = "60"
 
 }

--- a/terraform/rescheduler.alpha.cds-snc.ca.tf
+++ b/terraform/rescheduler.alpha.cds-snc.ca.tf
@@ -1,9 +1,9 @@
 resource "aws_route53_record" "_acm-validation-rescheduler-alpha-cds-snc-ca-CNAME" {
-    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
-    name    = "_124e31a4e6b52e341c197ae439978b0e.rescheduler.alpha.cds-snc.ca."
-    type    = "CNAME"
-    records = [
-        "_5cf85d02e07acc96d47d85ce22c348b0.kirrbxfjtw.acm-validations.aws."
-    ]
-    ttl     = "60"
+  zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
+  name    = "_124e31a4e6b52e341c197ae439978b0e.rescheduler.alpha.cds-snc.ca."
+  type    = "CNAME"
+  records = [
+    "_5cf85d02e07acc96d47d85ce22c348b0.kirrbxfjtw.acm-validations.aws."
+  ]
+  ttl = "60"
 }

--- a/terraform/rescheduler.cds-snc.ca.tf
+++ b/terraform/rescheduler.cds-snc.ca.tf
@@ -1,66 +1,66 @@
 resource "aws_route53_record" "rescheduler-cds-snc-ca-CNAME" {
-    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
-    name    = "rescheduler.cds-snc.ca"
-    type    = "A"
-    alias {
-        name                   = "d2q7bfe7f2hrcj.cloudfront.net"
-        zone_id                = "Z2FDTNDATAQYW2"
-        evaluate_target_health = true
-    }
+  zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
+  name    = "rescheduler.cds-snc.ca"
+  type    = "A"
+  alias {
+    name                   = "d2q7bfe7f2hrcj.cloudfront.net"
+    zone_id                = "Z2FDTNDATAQYW2"
+    evaluate_target_health = true
+  }
 }
 
 resource "aws_route53_record" "wildcard-rescheduler-cds-snc-ca-CNAME" {
-    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
-    name    = "*.rescheduler.cds-snc.ca"
-    type    = "A"
-    alias {
-        name                   = "d2q7bfe7f2hrcj.cloudfront.net"
-        zone_id                = "Z2FDTNDATAQYW2"
-        evaluate_target_health = true
-    }
+  zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
+  name    = "*.rescheduler.cds-snc.ca"
+  type    = "A"
+  alias {
+    name                   = "d2q7bfe7f2hrcj.cloudfront.net"
+    zone_id                = "Z2FDTNDATAQYW2"
+    evaluate_target_health = true
+  }
 }
 
 resource "aws_route53_record" "_acme-challenge-rescheduler-cds-snc-ca-TXT" {
-    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
-    name    = "_acme-challenge.rescheduler.cds-snc.ca"
-    type    = "TXT"
-    records = [
-        "YbzOaNCq_WMvje60niyhaAJx5-1N4XtrfKyxmhHsE0Y", 
-        "-ywp6oma6Y5KcIJogfA7RjBh3Qvhj6ZkoIYpPKt1wqY"
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
+  name    = "_acme-challenge.rescheduler.cds-snc.ca"
+  type    = "TXT"
+  records = [
+    "YbzOaNCq_WMvje60niyhaAJx5-1N4XtrfKyxmhHsE0Y",
+    "-ywp6oma6Y5KcIJogfA7RjBh3Qvhj6ZkoIYpPKt1wqY"
+  ]
+  ttl = "300"
 
 }
 
 resource "aws_route53_record" "_faa1db50e36e98191aefeeb9548c9165-rescheduler-cds-snc-ca-CNAME" {
-    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
-    name    = "_faa1db50e36e98191aefeeb9548c9165.rescheduler.cds-snc.ca"
-    type    = "CNAME"
-    records = [
-        "_f7f15af1bf1c1c2ee7de91625cfa62e9.tljzshvwok.acm-validations.aws."
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
+  name    = "_faa1db50e36e98191aefeeb9548c9165.rescheduler.cds-snc.ca"
+  type    = "CNAME"
+  records = [
+    "_f7f15af1bf1c1c2ee7de91625cfa62e9.tljzshvwok.acm-validations.aws."
+  ]
+  ttl = "300"
 
 }
 
 resource "aws_route53_record" "_9ad5e390e0591a7c0fee72f5280dc709-rescheduler-cds-snc-ca-CNAME" {
-    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
-    name    = "_9ad5e390e0591a7c0fee72f5280dc709.rescheduler.cds-snc.ca."
-    type    = "CNAME"
-    records = [
-        "_9213aa05d321dcdf588698442349a0f7.kirrbxfjtw.acm-validations.aws."
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
+  name    = "_9ad5e390e0591a7c0fee72f5280dc709.rescheduler.cds-snc.ca."
+  type    = "CNAME"
+  records = [
+    "_9213aa05d321dcdf588698442349a0f7.kirrbxfjtw.acm-validations.aws."
+  ]
+  ttl = "300"
 
 }
 
 resource "aws_route53_record" "_1e29e5064d202307d185782ac5c428ab-rescheduler-cds-snc-ca-CNAME" {
-    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
-    name    = "_1e29e5064d202307d185782ac5c428ab.rescheduler.cds-snc.ca."
-    type    = "CNAME"
-    records = [
-        "_b59d6e58723675a01fe65e054dee675c.wggjkglgrm.acm-validations.aws."
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
+  name    = "_1e29e5064d202307d185782ac5c428ab.rescheduler.cds-snc.ca."
+  type    = "CNAME"
+  records = [
+    "_b59d6e58723675a01fe65e054dee675c.wggjkglgrm.acm-validations.aws."
+  ]
+  ttl = "300"
 
 }

--- a/terraform/service-dashboard.cds-snc.ca.tf
+++ b/terraform/service-dashboard.cds-snc.ca.tf
@@ -1,10 +1,10 @@
 resource "aws_route53_record" "service-dashboard-cds-snc-ca-A" {
-    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
-    name    = "service-dashboard.cds-snc.ca"
-    type    = "A"
-    records = [
-        "52.237.20.235"
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
+  name    = "service-dashboard.cds-snc.ca"
+  type    = "A"
+  records = [
+    "52.237.20.235"
+  ]
+  ttl = "300"
 
 }

--- a/terraform/statcan.alpha.canada.ca.tf
+++ b/terraform/statcan.alpha.canada.ca.tf
@@ -1,39 +1,39 @@
 resource "aws_route53_record" "statistics-alpha-canada-ca-CNAME" {
-    zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
-    name    = "statistics.alpha.canada.ca"
-    type    = "CNAME"
-    records = [
-        "www-alpha.prod.cloud.statcan.ca"
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "statistics.alpha.canada.ca"
+  type    = "CNAME"
+  records = [
+    "www-alpha.prod.cloud.statcan.ca"
+  ]
+  ttl = "300"
 }
 
 resource "aws_route53_record" "statistique-alpha-canada-ca-CNAME" {
-    zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
-    name    = "statistique.alpha.canada.ca"
-    type    = "CNAME"
-    records = [
-        "www-alpha.prod.cloud.statcan.ca"
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "statistique.alpha.canada.ca"
+  type    = "CNAME"
+  records = [
+    "www-alpha.prod.cloud.statcan.ca"
+  ]
+  ttl = "300"
 }
 
 resource "aws_route53_record" "energy-information-alpha-canada-ca-CNAME" {
-    zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
-    name    = "energy-information.alpha.canada.ca"
-    type    = "CNAME"
-    records = [
-        "www-alpha.prod.cloud.statcan.ca"
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "energy-information.alpha.canada.ca"
+  type    = "CNAME"
+  records = [
+    "www-alpha.prod.cloud.statcan.ca"
+  ]
+  ttl = "300"
 }
 
 resource "aws_route53_record" "information-energie-alpha-canada-ca-CNAME" {
-    zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
-    name    = "information-energie.alpha.canada.ca"
-    type    = "CNAME"
-    records = [
-        "www-alpha.prod.cloud.statcan.ca"
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "information-energie.alpha.canada.ca"
+  type    = "CNAME"
+  records = [
+    "www-alpha.prod.cloud.statcan.ca"
+  ]
+  ttl = "300"
 }

--- a/terraform/tbs.alpha.canada.ca.tf
+++ b/terraform/tbs.alpha.canada.ca.tf
@@ -1,13 +1,13 @@
 resource "aws_route53_record" "tbs-alpha-canada-ca-NS" {
-    zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
-    name    = "tbs.alpha.canada.ca"
-    type    = "NS"
-    records = [
-        "ns1-09.azure-dns.com",
-        "ns2-09.azure-dns.net",
-        "ns3-09.azure-dns.org",
-        "ns4-09.azure-dns.info"
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "tbs.alpha.canada.ca"
+  type    = "NS"
+  records = [
+    "ns1-09.azure-dns.com",
+    "ns2-09.azure-dns.net",
+    "ns3-09.azure-dns.org",
+    "ns4-09.azure-dns.info"
+  ]
+  ttl = "300"
 
 }

--- a/terraform/tell-us.cds-snc.ca.tf
+++ b/terraform/tell-us.cds-snc.ca.tf
@@ -1,21 +1,21 @@
 resource "aws_route53_record" "tell-us-cds-snc-ca-A" {
-    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
-    name    = "tell-us.cds-snc.ca"
-    type    = "A"
-    records = [
-        "35.203.57.200"
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
+  name    = "tell-us.cds-snc.ca"
+  type    = "A"
+  records = [
+    "35.203.57.200"
+  ]
+  ttl = "300"
 
 }
 
 resource "aws_route53_record" "racontez-nous-cds-snc-ca-A" {
-    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
-    name    = "racontez-nous.cds-snc.ca"
-    type    = "A"
-    records = [
-        "35.203.57.200"
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
+  name    = "racontez-nous.cds-snc.ca"
+  type    = "A"
+  records = [
+    "35.203.57.200"
+  ]
+  ttl = "300"
 
 }

--- a/terraform/tracker-alpha-canada-ca.tf
+++ b/terraform/tracker-alpha-canada-ca.tf
@@ -5,7 +5,7 @@ resource "aws_route53_record" "tracker-alpha-canada-ca-A" {
   records = [
     "34.95.5.243"
   ]
-  ttl     = "300"
+  ttl = "300"
 }
 
 resource "aws_route53_record" "suivi-alpha-canada-ca-A" {
@@ -15,5 +15,5 @@ resource "aws_route53_record" "suivi-alpha-canada-ca-A" {
   records = [
     "34.95.5.243"
   ]
-  ttl     = "300"
+  ttl = "300"
 }

--- a/terraform/vac-benefits-finder.cds-snc.ca.tf
+++ b/terraform/vac-benefits-finder.cds-snc.ca.tf
@@ -1,10 +1,10 @@
 resource "aws_route53_record" "vac-benefits-finder-cds-snc-ca-A" {
-    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
-    name    = "vac-benefits-finder.cds-snc.ca"
-    type    = "A"
-    records = [
-        "52.237.20.235"
-    ]
-    ttl     = "300"
+  zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
+  name    = "vac-benefits-finder.cds-snc.ca"
+  type    = "A"
+  records = [
+    "52.237.20.235"
+  ]
+  ttl = "300"
 
 }

--- a/terraform/web-templates.pspc.alpha.canada.ca.tf
+++ b/terraform/web-templates.pspc.alpha.canada.ca.tf
@@ -5,5 +5,5 @@ resource "aws_route53_record" "web-templates-pspc-alpha-canada-ca-A" {
   records = [
     "52.237.15.42"
   ]
-  ttl     = "300"
+  ttl = "300"
 }


### PR DESCRIPTION
Fixes #131

- Bump Terraform to 0.13
- Change how the AWS provider is declared
- Fix warnings
- `fmt` all the files