### PR TITLE
Add CNAME for micro-acquisition.alpha.canada.ca

### DIFF
--- a/terraform/micro-acquisition.alpha.canada.ca.tf
+++ b/terraform/micro-acquisition.alpha.canada.ca.tf
@@ -1,6 +1,6 @@
 resource "aws_route53_record" "micro-acquisition-alpha-canada-ca-CNAME" {
-    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
-    name    = "micro-acquisition-alpha-canada-ca-CNAME"
+    zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+    name    = "micro-acquisition.alpha.canada.ca"
     type    = "CNAME"
     records = [
         "canada-ca.github.io"

--- a/terraform/micro-acquisition.alpha.canada.ca.tf
+++ b/terraform/micro-acquisition.alpha.canada.ca.tf
@@ -1,0 +1,9 @@
+resource "aws_route53_record" "micro-acquisition-alpha-canada-ca-CNAME" {
+    zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
+    name    = "micro-acquisition-alpha-canada-ca-CNAME"
+    type    = "CNAME"
+    records = [
+        "canada-ca.github.io"
+    ]
+    ttl     = "300"
+}


### PR DESCRIPTION
New tf file to add CNAME for https://micro-acquisition.alpha.canada.ca.

The goal is to link it to this Github Pages Website here
https://canada-ca.github.io/micro-acquisition/

Thanks!

cc. @RachelMuston
