### PR TITLE
Add COVID Alert QR Code Registration site URLs

### DIFF
--- a/terraform/covid-alert-portal.alpha.canada.ca.tf
+++ b/terraform/covid-alert-portal.alpha.canada.ca.tf
@@ -19,4 +19,27 @@ resource "aws_route53_record" "portail-alerte-covid-alpha-canada-ca-CNAME" {
     "covid-alert-portal.alpha.canada.ca"
   ]
   ttl = "300"
+}
+
+resource "aws_route53_record" "covid-alert-portal-alpha-canada-ca-NS" {
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "covid-alert-qr-poster.alpha.canada.ca"
+  type    = "NS"
+  records = [
+    "ns-905.awsdns-49.net",
+    "ns-29.awsdns-03.com",
+    "ns-2045.awsdns-63.co.uk",
+    "ns-1156.awsdns-16.org"
+  ]
+  ttl = "300"
+}
+
+resource "aws_route53_record" "portail-alerte-covid-alpha-canada-ca-CNAME" {
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "alerte-covid-affiche-qr.alpha.canada.ca"
+  type    = "CNAME"
+  records = [
+    "covid-alert-qr-poster.alpha.canada.ca"
+  ]
+  ttl = "300"
 } 

--- a/terraform/covid-alert-portal.alpha.canada.ca.tf
+++ b/terraform/covid-alert-portal.alpha.canada.ca.tf
@@ -21,7 +21,7 @@ resource "aws_route53_record" "portail-alerte-covid-alpha-canada-ca-CNAME" {
   ttl = "300"
 }
 
-resource "aws_route53_record" "covid-alert-portal-alpha-canada-ca-NS" {
+resource "aws_route53_record" "covid-alert-qr-poster-alpha-canada-ca-NS" {
   zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
   name    = "covid-alert-qr-poster.alpha.canada.ca"
   type    = "NS"
@@ -34,7 +34,7 @@ resource "aws_route53_record" "covid-alert-portal-alpha-canada-ca-NS" {
   ttl = "300"
 }
 
-resource "aws_route53_record" "portail-alerte-covid-alpha-canada-ca-CNAME" {
+resource "aws_route53_record" "alerte-covid-affiche-qr-alpha-canada-ca-CNAME" {
   zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
   name    = "alerte-covid-affiche-qr.alpha.canada.ca"
   type    = "CNAME"

--- a/terraform/covid-alert-portal.alpha.canada.ca.tf
+++ b/terraform/covid-alert-portal.alpha.canada.ca.tf
@@ -26,10 +26,10 @@ resource "aws_route53_record" "covid-alert-qr-poster-alpha-canada-ca-NS" {
   name    = "covid-alert-qr-poster.alpha.canada.ca"
   type    = "NS"
   records = [
-    "ns-905.awsdns-49.net",
-    "ns-29.awsdns-03.com",
-    "ns-2045.awsdns-63.co.uk",
-    "ns-1156.awsdns-16.org"
+    "ns-385.awsdns-48.com",
+    "ns-1866.awsdns-41.co.uk",
+    "ns-1226.awsdns-25.org",
+    "ns-808.awsdns-37.net"
   ]
   ttl = "300"
 }


### PR DESCRIPTION
# Summary | Résumé

Add new URLs for COVID Alert QR Code Registration site
