### PR TITLE
Add k8s

### DIFF
--- a/terraform/notification.canada.ca-zone.tf
+++ b/terraform/notification.canada.ca-zone.tf
@@ -39,6 +39,16 @@ resource "aws_route53_record" "api-notification-canada-ca-A" {
   ttl = "300"
 }
 
+resource "aws_route53_record" "api-k8s-notification-canada-ca-A" {
+  zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
+  name    = "api-k8s.notification.canada.ca"
+  type    = "CNAME"
+  records = [
+    local.notification_alb
+  ]
+  ttl = "300"
+}
+
 resource "aws_route53_record" "api-lambda-notification-canada-ca-A" {
   zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
   name    = "api-lambda.notification.canada.ca"


### PR DESCRIPTION
# Summary | Résumé

Give the k8s cluster api its own endpoint to make it easier to access directly (ex: for heartbeat)
