### PR TITLE
feat: log4shell dns capture

### DIFF
--- a/terraform/tracker-alpha-canada-ca.tf
+++ b/terraform/tracker-alpha-canada-ca.tf
@@ -33,7 +33,7 @@ resource "aws_route53_record" "ns1-log4shell-tracker-alpha-canada-ca-A" {
   name    = "ns1-log4shell.tracker.alpha.canada.ca"
   type    = "A"
   records = [
-    "34.95.5.243"
+    "34.95.53.80"
   ]
   ttl = "300"
 }

--- a/terraform/tracker-alpha-canada-ca.tf
+++ b/terraform/tracker-alpha-canada-ca.tf
@@ -18,9 +18,19 @@ resource "aws_route53_record" "suivi-alpha-canada-ca-A" {
   ttl = "300"
 }
 
-resource "aws_route53_record" "log4shell-tracker-alpha-canada-ca-A" {
+resource "aws_route53_record" "log4shell-tracker-alpha-canada-ca-NS" {
   zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
   name    = "log4shell.tracker.alpha.canada.ca"
+  type    = "NS"
+  records = [
+    "ns1-log4shell.tracker.alpha.canada.ca",
+  ]
+  ttl = "300"
+}
+
+resource "aws_route53_record" "ns1-log4shell-tracker-alpha-canada-ca-A" {
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "ns1-log4shell.tracker.alpha.canada.ca"
   type    = "A"
   records = [
     "34.95.5.243"


### PR DESCRIPTION
This PR adds a nameserver zone for `log4shell.tracker.alpha.canada.ca` as well as an A record to a nameserver for that subdomain. Any requests made to `log4shell.tracker.alpha.canada.ca` and any subdomains to that domain are now sent to the nameserver for resolution.