### PR TITLE
add new api gateway domain name values

### DIFF
--- a/terraform/notification.canada.ca-zone.tf
+++ b/terraform/notification.canada.ca-zone.tf
@@ -12,9 +12,10 @@ output "notification-canada-ca-ns" {
 }
 
 locals {
-  notification_alb       = "notification-production-alb-1685085140.ca-central-1.elb.amazonaws.com"
-  notification_zone_id   = "ZQSVJUPU6J1EY"
-  api_lambda_app_gateway = "d-3hv37fqgbg.execute-api.ca-central-1.amazonaws.com"
+  notification_alb                          = "notification-production-alb-1685085140.ca-central-1.elb.amazonaws.com"
+  notification_zone_id                      = "ZQSVJUPU6J1EY"
+  api_lambda_gateway_domain_name_api_lambda = "d-0jho4qbdqi.execute-api.ca-central-1.amazonaws.com"
+  api_lambda_gateway_domain_name_api        = "d-jwtzdgd9qg.execute-api.ca-central-1.amazonaws.com"
 }
 
 resource "aws_route53_record" "notification-canada-ca-ALIAS" {
@@ -54,7 +55,7 @@ resource "aws_route53_record" "api-lambda-notification-canada-ca-A" {
   name    = "api-lambda.notification.canada.ca"
   type    = "CNAME"
   records = [
-    local.api_lambda_app_gateway
+    local.api_lambda_gateway_domain_name_api_lambda
   ]
   ttl = "300"
 }


### PR DESCRIPTION
# Summary | Résumé

We recreated the api-lambda custom domain names for the Notify api lambda api gateway.
We also added a domain name for api (in preparation for the canary test). Adding it here even though we don't need it yet.

Note that the domain `api-lambda.notification.canada.ca` is not used in production. It exists as a way for us to hit the api lambda for testing.

# Test instructions | Instructions pour tester la modification

