### PR TITLE
make Notify api record weighted

### DIFF
--- a/terraform/notification.canada.ca-zone.tf
+++ b/terraform/notification.canada.ca-zone.tf
@@ -37,7 +37,11 @@ resource "aws_route53_record" "api-notification-canada-ca-A" {
   records = [
     local.notification_alb
   ]
-  ttl = "300"
+  ttl            = "60"
+  set_identifier = "loadbalancer"
+  weighted_routing_policy {
+    weight = 100
+  }
 }
 
 resource "aws_route53_record" "api-k8s-notification-canada-ca-A" {


### PR DESCRIPTION
# Summary | Résumé

https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/cds-snc/notification-planning/266

Need to make this record weighted in preparation for the canary test. We also lower the ttl to make it easier to revert 😅 

**Note** ~that we will first modify the record using click ops and then do a terraform import. At this point, this PR should match the system and the plan / apply should be empty.~ I don't think we need to do this since the plan claims it'll change in place rather than being replaced.