### PR TITLE
feat: set Notify Lambda API DNS weight to 5%

### DIFF
--- a/terraform/notification.canada.ca-zone.tf
+++ b/terraform/notification.canada.ca-zone.tf
@@ -203,9 +203,10 @@ resource "aws_route53_record" "notification-canada-ca-SPF" {
   name    = "notification.canada.ca"
   type    = "TXT"
   records = [
-    "v=spf1 include:amazonses.com -all",
     # Used for https://postmaster.google.com
-    "google-site-verification=KMFWVel40xicbDXojkXz_1B2gBlPFSqF69cVdH_dfn0"
+    "google-site-verification=KMFWVel40xicbDXojkXz_1B2gBlPFSqF69cVdH_dfn0",
+    "google-site-verification=WNq0Z6naWk2E9SfS9eYq6Y6ZHH29nmkgox3chj5I9iE",
+    "v=spf1 include:amazonses.com -all"
   ]
   ttl = "300"
 }

--- a/terraform/notification.canada.ca-zone.tf
+++ b/terraform/notification.canada.ca-zone.tf
@@ -40,7 +40,7 @@ resource "aws_route53_record" "api-notification-canada-ca-A" {
   ttl            = "60"
   set_identifier = "loadbalancer"
   weighted_routing_policy {
-    weight = 100
+    weight = 95
   }
 }
 
@@ -54,7 +54,7 @@ resource "aws_route53_record" "lambda-api-notification-canada-ca-A" {
   ttl            = "60"
   set_identifier = "lambda"
   weighted_routing_policy {
-    weight = 0
+    weight = 5
   }
 }
 


### PR DESCRIPTION
# Summary
This will route 5% of requests to the Notify API to the API Gateway
and Lambda infrastructure.  The remaining 95% will continue to
be served by the load balancer and Kubernetes API pods.

To rollback, reset the weights and re-deploy.  The 60 second
TTL on the records will ensure a short period of impacted users.

# Note
This PR also contains an unrelated TXT record change that had been 
added manually in the console.

# Related
* cds-snc/notification-planning#380