### PR TITLE
fix: remove Notify Lambda API weighting

### DIFF
--- a/terraform/notification.canada.ca-zone.tf
+++ b/terraform/notification.canada.ca-zone.tf
@@ -40,7 +40,7 @@ resource "aws_route53_record" "api-notification-canada-ca-A" {
   ttl            = "60"
   set_identifier = "loadbalancer"
   weighted_routing_policy {
-    weight = 95
+    weight = 100
   }
 }
 
@@ -54,7 +54,7 @@ resource "aws_route53_record" "lambda-api-notification-canada-ca-A" {
   ttl            = "60"
   set_identifier = "lambda"
   weighted_routing_policy {
-    weight = 5
+    weight = 0
   }
 }
 


### PR DESCRIPTION
# Summary
We're investigating a bug where the wrong SSL certificate is sporadically
returned when requests are made to `api.notification.canada.ca`.

In the errors cases, the SSL certificate only includes a Subject Alternative
Name for the API Gateway's execute URL of
`*.execute-api.ca-central-1.amazonaws.com`