### PR TITLE
feat: Notify Lambda API 5% traffic

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+terraform 0.13.6

--- a/terraform/notification.canada.ca-zone.tf
+++ b/terraform/notification.canada.ca-zone.tf
@@ -44,7 +44,7 @@ resource "aws_route53_record" "api-notification-canada-ca-A" {
 
   set_identifier = "loadbalancer"
   weighted_routing_policy {
-    weight = 100
+    weight = 95
   }
 }
 
@@ -61,7 +61,7 @@ resource "aws_route53_record" "lambda-api-notification-canada-ca-A" {
 
   set_identifier = "lambda"
   weighted_routing_policy {
-    weight = 0
+    weight = 5
   }
 }
 


### PR DESCRIPTION
# Summary
Update the `api.notification.canada.ca` weighted records to have
the Lambda API serve 5% of traffic, while the Kubernetes API
pods handle the other 95%.

Also includes an [asdf](https://asdf-vm.com/) `.tool-versions` file to pin the Terraform
version for any local Terraform commands.

# Related
* cds-snc/notification-planning#438