### PR TITLE
fix: `api-lambda.notification.canada.ca` should be ALIAS

### DIFF
--- a/terraform/notification.canada.ca-zone.tf
+++ b/terraform/notification.canada.ca-zone.tf
@@ -78,11 +78,13 @@ resource "aws_route53_record" "api-k8s-notification-canada-ca-A" {
 resource "aws_route53_record" "api-lambda-notification-canada-ca-A" {
   zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
   name    = "api-lambda.notification.canada.ca"
-  type    = "CNAME"
-  records = [
-    local.api_lambda_gateway_domain_name_api_lambda
-  ]
-  ttl = "300"
+  type    = "A"
+
+  alias {
+    name                   = local.api_lambda_gateway_domain_name_api_lambda
+    zone_id                = local.api_gateway_regional_zone_id
+    evaluate_target_health = true
+  }
 }
 
 resource "aws_route53_record" "document-notification-canada-ca-A" {


### PR DESCRIPTION
# Summary
The API Gateway custom domain name record should be an ALIAS
instead of CNAME.

# Related
* #226 
* cds-snc/notification-planning#437