### PR TITLE
feat: increase Notify Lambda API traffic to 10%

### DIFF
--- a/terraform/notification.canada.ca-zone.tf
+++ b/terraform/notification.canada.ca-zone.tf
@@ -44,7 +44,7 @@ resource "aws_route53_record" "api-notification-canada-ca-A" {
 
   set_identifier = "loadbalancer"
   weighted_routing_policy {
-    weight = 95
+    weight = 90
   }
 }
 
@@ -61,7 +61,7 @@ resource "aws_route53_record" "lambda-api-notification-canada-ca-A" {
 
   set_identifier = "lambda"
   weighted_routing_policy {
-    weight = 5
+    weight = 10
   }
 }
 


### PR DESCRIPTION
# Summary
Update the weighting on the Lambda API to handle ~10% of requests.

# Related
* cds-snc/notification-planning#438