### PR TITLE
Url shortener subdomain delegation (url-shortener.alpha.canada.ca)

### DIFF
--- a/terraform/url-shortener.alpha.canada.ca.tf
+++ b/terraform/url-shortener.alpha.canada.ca.tf
@@ -1,0 +1,12 @@
+resource "aws_route53_record" "url-shortener-alpha-canada-ca-NS" {
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "url-shortener.alpha.canada.ca"
+  type    = "NS"
+  records = [
+    "ns-1259.awsdns-29.org",
+    "ns-720.awsdns-26.net",
+    "ns-1942.awsdns-50.co.uk",
+    "ns-8.awsdns-01.com"
+  ]
+  ttl = "300"
+}


### PR DESCRIPTION
# Summary

This will provide subdomain delegation to the url-shortener AWS account's hosted zone. 

The Draft PR with the infrastructure code for url-shortener can be found [here](https://github.com/cds-snc/url-shortener/pull/6). 
