### PR TITLE
feat: set Notify Lambda API weight to 25%

### DIFF
--- a/terraform/notification.canada.ca-zone.tf
+++ b/terraform/notification.canada.ca-zone.tf
@@ -44,7 +44,7 @@ resource "aws_route53_record" "api-notification-canada-ca-A" {
 
   set_identifier = "loadbalancer"
   weighted_routing_policy {
-    weight = 90
+    weight = 75
   }
 }
 
@@ -61,7 +61,7 @@ resource "aws_route53_record" "lambda-api-notification-canada-ca-A" {
 
   set_identifier = "lambda"
   weighted_routing_policy {
-    weight = 10
+    weight = 25
   }
 }
 


### PR DESCRIPTION
# Summary
Update the `api.notification.canada.ca` DNS weight to have
75% Kubernetes, 25% Lambda.

# Related
* cds-snc/notification-planning#438