### PR TITLE
feat: set Lambda API to 50% traffic

### DIFF
--- a/terraform/notification.canada.ca-zone.tf
+++ b/terraform/notification.canada.ca-zone.tf
@@ -44,7 +44,7 @@ resource "aws_route53_record" "api-notification-canada-ca-A" {
 
   set_identifier = "loadbalancer"
   weighted_routing_policy {
-    weight = 75
+    weight = 50
   }
 }
 
@@ -61,7 +61,7 @@ resource "aws_route53_record" "lambda-api-notification-canada-ca-A" {
 
   set_identifier = "lambda"
   weighted_routing_policy {
-    weight = 25
+    weight = 50
   }
 }
 


### PR DESCRIPTION
# Summary
Update the weighting of the Notify API DNS records so that
50% is Lambda API and 50% is Kubernetes.

# Related
* cds-snc/notification-planning#438