### PR TITLE
chore: update workflows to new default branch

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -3,7 +3,7 @@ name: "Terraform apply"
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - "terraform/**"
 

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -3,7 +3,7 @@ name: "Terraform plan"
 on:
   pull_request:
     branches:
-      - master
+      - main
     paths:
       - "terraform/**"
       - ".github/workflows/terraform-plan.yml"


### PR DESCRIPTION
# Summary
Default branch of the repo has been changed to `main`.

Anyone with a local clone of this repo will need to run the following to sync everything up:
```sh
git branch -m master main
git fetch origin
git branch -u origin/main main
git remote set-head origin -a
```