### PR TITLE
fix: add terraform init/plan steps

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - "terraform/**"
+      - ".github/workflows/terraform-apply.yml"
 
 env:
   AWS_REGION: ca-central-1
@@ -25,6 +26,14 @@ jobs:
 
       - name: Setup Terraform tools
         uses: cds-snc/terraform-tools-setup@v1
+
+      - name: Terraform init
+        working-directory: terraform
+        run: terraform init
+
+      - name: Terraform plan
+        working-directory: terraform
+        run: terraform plan        
 
       - name: Terraform apply
         working-directory: terraform


### PR DESCRIPTION
# Summary
Previous runs were failing because no `terraform init` was
run.  This also adds a `terraform plan` step as a final sanity
check.

# ⚠️  Note
We should expect to see the following PR's changes in the
Terraform plan as they were not applied successfully:
* #241 