### PR TITLE
sp.ssc.alpha.canada.ca

### DIFF
--- a/terraform/sp.ssc.alpha.canada.ca.tf
+++ b/terraform/sp.ssc.alpha.canada.ca.tf
@@ -1,6 +1,6 @@
-resource "aws_route53_record" "ssc-sp-alpha-canada-ca-NS" {
+resource "aws_route53_record" "sp-ssc-alpha-canada-ca-NS" {
   zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
-  name    = "ssc-sp.alpha.canada.ca"
+  name    = "sp.ssc.alpha.canada.ca"
   type    = "NS"
   records = [
     "ns1-32.azure-dns.com",

--- a/terraform/ssc-sp.alpha.canada.ca.tf
+++ b/terraform/ssc-sp.alpha.canada.ca.tf
@@ -1,0 +1,12 @@
+resource "aws_route53_record" "ssc-sp-alpha-canada-ca-NS" {
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "ssc-sp.alpha.canada.ca"
+  type    = "NS"
+  records = [
+    "ns1-32.azure-dns.com",
+    "ns2-32.azure-dns.net",
+    "ns3-32.azure-dns.org",
+    "ns4-32.azure-dns.info"
+  ]
+  ttl = "300"
+}


### PR DESCRIPTION
# Summary | Résumé

Requesting a subdomain(sp.ssc.alpha.canada.ca) be registered under alpha.canada.ca. Subdomain will be used to create other subdomains that will be used for experimentation projects with in the SSC Science Program cloud devops team. 

Projects will be GC science in nature and eventually be moved off of alpha.canada.ca and moved to science.cloud-nuage.canada.ca or other production like domains.

---

# Test instructions | Instructions pour tester la modification

N/A