### PR TITLE
fix: remove repo name job condition

### DIFF
--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -17,7 +17,6 @@ jobs:
 
   terraform-plan:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
 
       - name: Checkout


### PR DESCRIPTION
# Summary
This condition prevents the `terraform plan` from running
on fork PRs.  The GitHub settings we have for this repo require
explicit approval before fork PRs are run, so we don't need
the condition anymore.