### PR TITLE
feat: SSC Science Program subdomain delegation

### DIFF
--- a/terraform/sp.ssc.alpha.canada.ca.tf
+++ b/terraform/sp.ssc.alpha.canada.ca.tf
@@ -1,0 +1,12 @@
+resource "aws_route53_record" "sp-ssc-alpha-canada-ca-NS" {
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "sp.ssc.alpha.canada.ca"
+  type    = "NS"
+  records = [
+    "ns1-35.azure-dns.com",
+    "ns2-35.azure-dns.net",
+    "ns3-35.azure-dns.org",
+    "ns4-35.azure-dns.info"
+  ]
+  ttl = "300"
+}


### PR DESCRIPTION
# Summary
Subdomain will be used to create other subdomains that will be
used for experimentation projects with in the SSC Science Program
cloud devops team.

Projects will be GC science in nature and eventually be moved
off of alpha.canada.ca and moved to science.cloud-nuage.canada.ca
or other production like domains.

Co-authored by: @johnkingbain

# Related
* Closes #249 