### PR TITLE
Delegate safeinputs dns

### DIFF
--- a/terraform/safeinputs-alpha-canada-ca.tf
+++ b/terraform/safeinputs-alpha-canada-ca.tf
@@ -1,0 +1,25 @@
+resource "aws_route53_record" "tracker-alpha-canada-ca-NS" {
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "safeinputs.alpha.canada.ca"
+  type    = "NS"
+  records = [
+    "ns-cloud-e1.googledomains.com.",
+    "ns-cloud-e2.googledomains.com.",
+    "ns-cloud-e3.googledomains.com.",
+    "ns-cloud-e4.googledomains.com.",
+  ]
+  ttl = "300"
+}
+
+resource "aws_route53_record" "suivi-alpha-canada-ca-NS" {
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "entreessecurisees.alpha.canada.ca"
+  type    = "NS"
+  records = [
+    "ns-cloud-e1.googledomains.com.",
+    "ns-cloud-e2.googledomains.com.",
+    "ns-cloud-e3.googledomains.com.",
+    "ns-cloud-e4.googledomains.com.",
+  ]
+  ttl = "300"
+}

--- a/terraform/safeinputs-alpha-canada-ca.tf
+++ b/terraform/safeinputs-alpha-canada-ca.tf
@@ -1,4 +1,4 @@
-resource "aws_route53_record" "tracker-alpha-canada-ca-NS" {
+resource "aws_route53_record" "safeinputs-alpha-canada-ca-NS" {
   zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
   name    = "safeinputs.alpha.canada.ca"
   type    = "NS"
@@ -11,7 +11,7 @@ resource "aws_route53_record" "tracker-alpha-canada-ca-NS" {
   ttl = "300"
 }
 
-resource "aws_route53_record" "suivi-alpha-canada-ca-NS" {
+resource "aws_route53_record" "entreessecurisees-alpha-canada-ca-NS" {
   zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
   name    = "entreessecurisees.alpha.canada.ca"
   type    = "NS"


### PR DESCRIPTION
Safeinputs is an innovation project at PHAC. As the name implies it's
aiming to safely handle inputs and that safety starts with encryption,
which requires a domain name... hence this PR.
