### PR TITLE
[PHAC] itap-piem.alpha-canada.ca

### DIFF
--- a/terraform/itap-piem.alpha-canada.ca.tf
+++ b/terraform/itap-piem.alpha-canada.ca.tf
@@ -1,4 +1,4 @@
-resource "aws_route53_record" "itap-piem.alpha-canada.ca-A" {
+resource "aws_route53_record" "itap-piem-alpha-canada.ca-A" {
   zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
   name    = "itap-piem.alpha-canada.ca"
   type    = "A"

--- a/terraform/itap-piem.alpha-canada.ca.tf
+++ b/terraform/itap-piem.alpha-canada.ca.tf
@@ -1,4 +1,4 @@
-resource "aws_route53_record" "itap-piem-alpha-canada.ca-A" {
+resource "aws_route53_record" "itap-piem-alpha-canada-ca-A" {
   zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
   name    = "itap-piem.alpha-canada.ca"
   type    = "A"

--- a/terraform/itap-piem.alpha-canada.ca.tf
+++ b/terraform/itap-piem.alpha-canada.ca.tf
@@ -1,0 +1,9 @@
+resource "aws_route53_record" "itap-piem.alpha-canada.ca-A" {
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "itap-piem.alpha-canada.ca"
+  type    = "A"
+  records = [
+    "34.111.247.109"
+  ]
+  ttl = "300"
+}


### PR DESCRIPTION
# Summary | Résumé

new DNS entry for itap-piem.alpha-canada.ca