### PR TITLE
Update the DNS record set IP

### DIFF
--- a/terraform/performance.alpha.canada.ca.tf
+++ b/terraform/performance.alpha.canada.ca.tf
@@ -3,7 +3,7 @@ resource "aws_route53_record" "performance-alpha-canada-ca-A" {
   name    = "performance.alpha.canada.ca"
   type    = "A"
   records = [
-    "52.237.15.42"
+    "20.220.167.149"
   ]
   ttl = "300"
 }
@@ -13,7 +13,7 @@ resource "aws_route53_record" "rendement-alpha-canada-ca-A" {
   name    = "rendement.alpha.canada.ca"
   type    = "A"
   records = [
-    "52.237.15.42"
+    "20.220.167.149"
   ]
   ttl = "300"
 }


### PR DESCRIPTION
We are changing the IP because our load balancer is using a new IP since it was redeployed.
