### PR TITLE
feat(statcan.alpha.canada.ca): add CNAME entries to allow for ACME DN…

### DIFF
--- a/terraform/statcan.alpha.canada.ca.tf
+++ b/terraform/statcan.alpha.canada.ca.tf
@@ -13,7 +13,7 @@ resource "aws_route53_record" "statistics-alpha-canada-ca-CNAME" {
   ttl = "300"
 }
 
-resource "aws_route53_record" "-acme-challenge-statistics-alpha-canada-ca-CNAME" {
+resource "aws_route53_record" "_acme-challenge-statistics-alpha-canada-ca-CNAME" {
   zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
   name    = join(".", [local.acme_challenge, aws_route53_record.statistics-alpha-canada-ca-CNAME.name])
   type    = "CNAME"
@@ -33,7 +33,7 @@ resource "aws_route53_record" "statistique-alpha-canada-ca-CNAME" {
   ttl = "300"
 }
 
-resource "aws_route53_record" "-acme-challenge-statistique-alpha-canada-ca-CNAME" {
+resource "aws_route53_record" "_acme-challenge-statistique-alpha-canada-ca-CNAME" {
   zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
   name    = join(".", [local.acme_challenge, aws_route53_record.statistique-alpha-canada-ca-CNAME.name])
   type    = "CNAME"
@@ -53,7 +53,7 @@ resource "aws_route53_record" "energy-information-alpha-canada-ca-CNAME" {
   ttl = "300"
 }
 
-resource "aws_route53_record" "-acme-challenge-energy-information-alpha-canada-ca-CNAME" {
+resource "aws_route53_record" "_acme-challenge-energy-information-alpha-canada-ca-CNAME" {
   zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
   name    = join(".", [local.acme_challenge, aws_route53_record.energy-information-alpha-canada-ca-CNAME.name])
   type    = "CNAME"
@@ -73,7 +73,7 @@ resource "aws_route53_record" "information-energie-alpha-canada-ca-CNAME" {
   ttl = "300"
 }
 
-resource "aws_route53_record" "-acme-challenge-information-energie-alpha-canada-ca-CNAME" {
+resource "aws_route53_record" "_acme-challenge-information-energie-alpha-canada-ca-CNAME" {
   zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
   name    = join(".", [local.acme_challenge, aws_route53_record.information-energie-alpha-canada-ca-CNAME.name])
   type    = "CNAME"

--- a/terraform/statcan.alpha.canada.ca.tf
+++ b/terraform/statcan.alpha.canada.ca.tf
@@ -1,9 +1,24 @@
+locals {
+  acme_challenge       = "_acme_challenge"
+  challenges_subdomain = "challenges.cloud.statcan.ca"
+}
+
 resource "aws_route53_record" "statistics-alpha-canada-ca-CNAME" {
   zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
   name    = "statistics.alpha.canada.ca"
   type    = "CNAME"
   records = [
     "www-alpha.prod.cloud.statcan.ca"
+  ]
+  ttl = "300"
+}
+
+resource "aws_route53_record" "-acme-challenge-statistics-alpha-canada-ca-CNAME" {
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = join(".", [local.acme_challenge, aws_route53_record.statistics-alpha-canada-ca-CNAME.name])
+  type    = "CNAME"
+  records = [
+    join(".", [aws_route53_record.statistics-alpha-canada-ca-CNAME.name, local.challenges_subdomain])
   ]
   ttl = "300"
 }
@@ -18,6 +33,16 @@ resource "aws_route53_record" "statistique-alpha-canada-ca-CNAME" {
   ttl = "300"
 }
 
+resource "aws_route53_record" "-acme-challenge-statistique-alpha-canada-ca-CNAME" {
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = join(".", [local.acme_challenge, aws_route53_record.statistique-alpha-canada-ca-CNAME.name])
+  type    = "CNAME"
+  records = [
+    join(".", [aws_route53_record.statistique-alpha-canada-ca-CNAME.name, local.challenges_subdomain])
+  ]
+  ttl = "300"
+}
+
 resource "aws_route53_record" "energy-information-alpha-canada-ca-CNAME" {
   zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
   name    = "energy-information.alpha.canada.ca"
@@ -28,12 +53,32 @@ resource "aws_route53_record" "energy-information-alpha-canada-ca-CNAME" {
   ttl = "300"
 }
 
+resource "aws_route53_record" "-acme-challenge-energy-information-alpha-canada-ca-CNAME" {
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = join(".", [local.acme_challenge, aws_route53_record.energy-information-alpha-canada-ca-CNAME.name])
+  type    = "CNAME"
+  records = [
+    join(".", [aws_route53_record.energy-information-alpha-canada-ca-CNAME.name, local.challenges_subdomain])
+  ]
+  ttl = "300"
+}
+
 resource "aws_route53_record" "information-energie-alpha-canada-ca-CNAME" {
   zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
   name    = "information-energie.alpha.canada.ca"
   type    = "CNAME"
   records = [
     "ccei-alpha.prod.cloud.statcan.ca"
+  ]
+  ttl = "300"
+}
+
+resource "aws_route53_record" "-acme-challenge-information-energie-alpha-canada-ca-CNAME" {
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = join(".", [local.acme_challenge, aws_route53_record.information-energie-alpha-canada-ca-CNAME.name])
+  type    = "CNAME"
+  records = [
+    join(".", [aws_route53_record.information-energie-alpha-canada-ca-CNAME.name, local.challenges_subdomain])
   ]
   ttl = "300"
 }


### PR DESCRIPTION
…S validation.

# Summary | Résumé

This Pull Request adds CNAMEs which point to the Statistics Canada cloud DNS. This allows use to use DNS's record following to perform DNS-based validation using the ACME protocol.

To take advantage of this, a CNAME with the following value must be configured for the `subdomain` requested:
`_acme_challenge.$subdomain.challenges.cloud.statcan.ca`

To achieve this and prevent input errors, the original resources are used to create these new records.

# Test instructions | Instructions pour tester la modification

The 4 following CNAMES are available:
- `_acme_challenge.statistics.alpha.canada.ca.challenges.cloud.statcan.ca`
- `_acme_challenge.statistique.alpha.canada.ca.challenges.cloud.statcan.ca`
- `_acme_challenge.energy-information.alpha.canada.ca.challenges.cloud.statcan.ca`
- `_acme_challenge.information-energie.alpha.canada.ca.challenges.cloud.statcan.ca`
---

