### PR TITLE
Redirect alpha API URL to live URL

### DIFF
--- a/terraform/notification.alpha.canada.ca.tf
+++ b/terraform/notification.alpha.canada.ca.tf
@@ -15,7 +15,9 @@ resource "aws_route53_record" "api-notification-alpha-canada-ca-A" {
   name    = "api.notification.alpha.canada.ca"
   type    = "CNAME"
   records = [
-    local.notification_alb
+    # Targets the Route53 production record to get through proper
+    # weighted redirection strategy (k8 or lambda).
+    "api.notification.canada.ca"
   ]
   ttl = "300"
 


### PR DESCRIPTION
# Summary | Résumé

GCNotify still get traffic hitting the API in kubernetes because many users still use the alpha API URL (i.e. api.notification.alpha.canada.ca). By redirecting the alpha API URL to the live production Route53 weighted record, all traffic should get through the lambda with current configuration.

# Test instructions | Instructions pour tester la modification

1. Hit the api.notification.alpha.canada.ca URL and check logs to see if it hits the kubernetes cluster or the lambda.
