### PR TITLE
Reverting DNS change to target alpha URL to lambda

### DIFF
--- a/terraform/notification.alpha.canada.ca.tf
+++ b/terraform/notification.alpha.canada.ca.tf
@@ -13,13 +13,12 @@ resource "aws_route53_record" "notification-alpha-canada-ca-ALIAS" {
 resource "aws_route53_record" "api-notification-alpha-canada-ca-A" {
   zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
   name    = "api.notification.alpha.canada.ca"
-  type    = "A"
+  type    = "CNAME"
+  records = [
+    local.notification_alb
+  ]
+  ttl = "300"
 
-  alias {
-    name                   = local.api_lambda_gateway_domain_name_api
-    zone_id                = local.api_gateway_regional_zone_id
-    evaluate_target_health = true
-  }
 }
 
 resource "aws_route53_record" "document-notification-alpha-canada-ca-A" {


### PR DESCRIPTION
# Summary | Résumé

Our trial failed again in production, so we are...

* Reverting DNS change to target alpha URL to lambda.

# Test instructions | Instructions pour tester la modification

It would be much better if we could test this in staging.
