### PR TITLE
Target api alpha domain to lambda api

### DIFF
--- a/terraform/notification.alpha.canada.ca.tf
+++ b/terraform/notification.alpha.canada.ca.tf
@@ -13,12 +13,13 @@ resource "aws_route53_record" "notification-alpha-canada-ca-ALIAS" {
 resource "aws_route53_record" "api-notification-alpha-canada-ca-A" {
   zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
   name    = "api.notification.alpha.canada.ca"
-  type    = "CNAME"
-  records = [
-    local.notification_alb
-  ]
-  ttl = "300"
+  type    = "A"
 
+  alias {
+    name                   = local.api_lambda_gateway_domain_name_api
+    zone_id                = local.api_gateway_regional_zone_id
+    evaluate_target_health = true
+  }
 }
 
 resource "aws_route53_record" "document-notification-alpha-canada-ca-A" {

--- a/terraform/notification.alpha.canada.ca.tf
+++ b/terraform/notification.alpha.canada.ca.tf
@@ -16,7 +16,7 @@ resource "aws_route53_record" "api-notification-alpha-canada-ca-A" {
   type    = "A"
 
   alias {
-    name                   = local.api_lambda_gateway_domain_name_api
+    name                   = local.api_lambda_gateway_domain_name_alt_api_lambda
     zone_id                = local.api_gateway_regional_zone_id
     evaluate_target_health = true
   }

--- a/terraform/notification.canada.ca-zone.tf
+++ b/terraform/notification.canada.ca-zone.tf
@@ -12,11 +12,12 @@ output "notification-canada-ca-ns" {
 }
 
 locals {
-  notification_alb                          = "notification-production-alb-1685085140.ca-central-1.elb.amazonaws.com"
-  notification_zone_id                      = "ZQSVJUPU6J1EY"
-  api_gateway_regional_zone_id              = "Z19DQILCV0OWEC" # ca-central-1
-  api_lambda_gateway_domain_name_api_lambda = "d-0jho4qbdqi.execute-api.ca-central-1.amazonaws.com"
-  api_lambda_gateway_domain_name_api        = "d-jwtzdgd9qg.execute-api.ca-central-1.amazonaws.com"
+  notification_alb                              = "notification-production-alb-1685085140.ca-central-1.elb.amazonaws.com"
+  notification_zone_id                          = "ZQSVJUPU6J1EY"
+  api_gateway_regional_zone_id                  = "Z19DQILCV0OWEC" # ca-central-1
+  api_lambda_gateway_domain_name_api_lambda     = "d-0jho4qbdqi.execute-api.ca-central-1.amazonaws.com"
+  api_lambda_gateway_domain_name_alt_api_lambda = "d-f9v7fu3260.execute-api.ca-central-1.amazonaws.com"
+  api_lambda_gateway_domain_name_api            = "d-jwtzdgd9qg.execute-api.ca-central-1.amazonaws.com"
 }
 
 resource "aws_route53_record" "notification-canada-ca-ALIAS" {


### PR DESCRIPTION
# Summary | Résumé

Target the api.notification.alpha.canada.ca to lambda API.

# Test instructions | Instructions pour tester la modification

Send a notification to the API using api.notification.alpha.canada.ca.