### PR TITLE
fix(statcan-alpha): fix typo with acme-challenge prefix.

### DIFF
--- a/terraform/statcan.alpha.canada.ca.tf
+++ b/terraform/statcan.alpha.canada.ca.tf
@@ -1,5 +1,5 @@
 locals {
-  acme_challenge       = "_acme_challenge"
+  acme_challenge       = "_acme-challenge"
   challenges_subdomain = "challenges.cloud.statcan.ca"
 }
 


### PR DESCRIPTION
# Summary | Résumé

A quick typo fix.
