### PR TITLE
chore: bump AWS provider to 3.x

### DIFF
--- a/bootstrap/init.tf
+++ b/bootstrap/init.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 2.70"
+      version = "~> 3.0"
     }
   }
 }

--- a/terraform/init.tf
+++ b/terraform/init.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 2.70"
+      version = "~> 3.0"
     }
   }
 }


### PR DESCRIPTION
# Summary
Update the Terraform AWS provider to the 3.x release.

Going through the upgrade notes from 2.x to 3.x, the only change thay could have impacted us was a difference in how the `aws_route53_zone` resource returns its `name` attribute.

In 3.x, it no longer includes a `.` suffix, but we do not make use of this attribute so there's no impact.

# Related
- **[Terraform 3.x upgrade guide](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-3-upgrade)**
- #307 
- cds-snc/platform-core-services#215