### PR TITLE
chore: bump AWS provider to 4.x

### DIFF
--- a/bootstrap/init.tf
+++ b/bootstrap/init.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.0"
+      version = "~> 4.0"
     }
   }
 }

--- a/terraform/init.tf
+++ b/terraform/init.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.0"
+      version = "~> 4.0"
     }
   }
 }


### PR DESCRIPTION
# Summary
Upgrade the Terraform AWS provider to the 4.x version.

There are no changes in the 3.x to 4.x upgrade guide that impact us.

# Related
- **[Terraform AWS 4.x upgrade guide](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-4-upgrade)**
- Closes cds-snc/platform-core-services#215
- Closes #307