### PR TITLE
Create design-system.alpha.canada.ca.tf

### DIFF
--- a/terraform/design-system.alpha.canada.ca.tf
+++ b/terraform/design-system.alpha.canada.ca.tf
@@ -1,0 +1,19 @@
+resource "aws_route53_record" "design-system-alpha-canada-ca-CNAME" {
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "design-system.alpha.canada.ca"
+  type    = "CNAME"
+  records = [
+    "cds-design-snc.netlify.app"
+  ]
+  ttl = "300"
+}
+
+resource "aws_route53_record" "systeme-design-alpha-canada-ca-CNAME" {
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "systeme-design.alpha.canada.ca"
+  type    = "CNAME"
+  records = [
+    "cds-design-snc.netlify.app"
+  ]
+  ttl = "300"
+}


### PR DESCRIPTION
# Summary | Résumé

Create design-system.alpha.canada.ca.tf to add CNAME record for design-system.alpha.canada.ca/systeme-design.alpha.canada.ca.
