### PR TITLE
fix: update URL shortener NS records

### DIFF
--- a/terraform/url-shortener.alpha.canada.ca.tf
+++ b/terraform/url-shortener.alpha.canada.ca.tf
@@ -1,12 +1,12 @@
 resource "aws_route53_record" "url-shortener-alpha-canada-ca-NS" {
   zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
-  name    = "url-shortener.alpha.canada.ca"
+  name    = "o.alpha.canada.ca"
   type    = "NS"
   records = [
-    "ns-1259.awsdns-29.org",
-    "ns-720.awsdns-26.net",
-    "ns-1942.awsdns-50.co.uk",
-    "ns-8.awsdns-01.com"
+    "ns-1053.awsdns-03.org.",
+    "ns-1594.awsdns-07.co.uk.",
+    "ns-308.awsdns-38.com.",
+    "ns-788.awsdns-34.net."
   ]
   ttl = "300"
 }


### PR DESCRIPTION
# Summary
Updates records to the new `o.alpha.canada.ca` hosted zone

# Related