### PR TITLE
feat: hosted zone for the Platform business unit

### DIFF
--- a/terraform/platform.canada.ca-zone.tf
+++ b/terraform/platform.canada.ca-zone.tf
@@ -1,0 +1,12 @@
+resource "aws_route53_zone" "platform-canada-ca-public" {
+  name    = "platform-plateforme.canada.ca"
+  comment = ""
+
+  tags = {
+    Project = "dns"
+  }
+}
+
+output "platform-canada-ca-ns" {
+  value = aws_route53_zone.platform-canada-ca-public.name_servers
+}


### PR DESCRIPTION
# Summary
Create a Route53 hosted zone `platform-plateforme.canada.ca`.