### PR TITLE
feat: Adding system status static website dns validation CNAME

### DIFF
--- a/terraform/notification.canada.ca-zone.tf
+++ b/terraform/notification.canada.ca-zone.tf
@@ -284,3 +284,12 @@ resource "aws_route53_record" "amazonses-inbound-notification-canada-ca-MX" {
   ttl = "300"
 }
 
+# DNS Validation for status.notification.canada.ca
+resource "aws_route53_record" "status-notification-validation-CNAME" {
+  zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
+  name    = "_7deec9582fbcae0f970d8192e402d455.status.notification.canada.ca"
+  type    = "CNAME"
+  records = ["_460cff15b0106252f78a3e2257c44d80.mhbtsbpdnt.acm-validations.aws."]
+  
+  ttl = "300"
+}

--- a/terraform/notification.canada.ca-zone.tf
+++ b/terraform/notification.canada.ca-zone.tf
@@ -290,6 +290,6 @@ resource "aws_route53_record" "status-notification-validation-CNAME" {
   name    = "_7deec9582fbcae0f970d8192e402d455.status.notification.canada.ca"
   type    = "CNAME"
   records = ["_460cff15b0106252f78a3e2257c44d80.mhbtsbpdnt.acm-validations.aws."]
-  
+
   ttl = "300"
 }


### PR DESCRIPTION
# Summary | Résumé

Adding the notify system status certificate validation record.

# Test instructions | Instructions pour tester la modification

TF Apply works, nslookup on 
_7deec9582fbcae0f970d8192e402d455.status.notification.canada.ca
should return:
_460cff15b0106252f78a3e2257c44d80.mhbtsbpdnt.acm-validations.aws.