### PR TITLE
feat: Adding the notify status cloudfront CNAME

### DIFF
--- a/terraform/notification.canada.ca-zone.tf
+++ b/terraform/notification.canada.ca-zone.tf
@@ -293,3 +293,13 @@ resource "aws_route53_record" "status-notification-validation-CNAME" {
 
   ttl = "300"
 }
+
+resource "aws_route53_record" "system-status-notification-canada-ca-cname" {
+  zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
+  name    = "status.notification.canada.ca"
+  type    = "CNAME"
+  records = [
+    "d2ica3mejnwxm3.cloudfront.net"
+  ]
+  ttl = "300"
+}


### PR DESCRIPTION
# Summary | Résumé

Disregard branch name - this is a CNAME, not an A record. 

Adding the notify system status CNAME to point to the new cloudfront distribution

# Test instructions | Instructions pour tester la modification

nslookup status.notification.canada.ca should resolve to:
d2ica3mejnwxm3.cloudfront.net