### PR TITLE
chore: retire unused design.alpha.canada.ca domain

### DIFF
--- a/terraform/design.canada.ca.tf
+++ b/terraform/design.canada.ca.tf
@@ -1,9 +1,0 @@
-resource "aws_route53_record" "design-alpha-canada-ca-CNAME" {
-  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
-  name    = "design.alpha.canada.ca"
-  type    = "CNAME"
-  records = [
-    "gallant-bassi-851d24.netlify.app"
-  ]
-  ttl = "300"
-}


### PR DESCRIPTION
# Summary | Résumé

`design.alpha.canada.ca` has not been used as the official domain since March 10, 2023

Resolves 
- https://github.com/cds-snc/design-gc-conception/issues/643