### PR TITLE
chore: remove unused StatsCan CNAMEs

### DIFF
--- a/terraform/statcan.alpha.canada.ca.tf
+++ b/terraform/statcan.alpha.canada.ca.tf
@@ -3,46 +3,6 @@ locals {
   challenges_subdomain = "challenges.cloud.statcan.ca"
 }
 
-resource "aws_route53_record" "statistics-alpha-canada-ca-CNAME" {
-  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
-  name    = "statistics.alpha.canada.ca"
-  type    = "CNAME"
-  records = [
-    "www-alpha.prod.cloud.statcan.ca"
-  ]
-  ttl = "300"
-}
-
-resource "aws_route53_record" "_acme-challenge-statistics-alpha-canada-ca-CNAME" {
-  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
-  name    = join(".", [local.acme_challenge, aws_route53_record.statistics-alpha-canada-ca-CNAME.name])
-  type    = "CNAME"
-  records = [
-    join(".", [aws_route53_record.statistics-alpha-canada-ca-CNAME.name, local.challenges_subdomain])
-  ]
-  ttl = "300"
-}
-
-resource "aws_route53_record" "statistique-alpha-canada-ca-CNAME" {
-  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
-  name    = "statistique.alpha.canada.ca"
-  type    = "CNAME"
-  records = [
-    "www-alpha.prod.cloud.statcan.ca"
-  ]
-  ttl = "300"
-}
-
-resource "aws_route53_record" "_acme-challenge-statistique-alpha-canada-ca-CNAME" {
-  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
-  name    = join(".", [local.acme_challenge, aws_route53_record.statistique-alpha-canada-ca-CNAME.name])
-  type    = "CNAME"
-  records = [
-    join(".", [aws_route53_record.statistique-alpha-canada-ca-CNAME.name, local.challenges_subdomain])
-  ]
-  ttl = "300"
-}
-
 resource "aws_route53_record" "energy-information-alpha-canada-ca-CNAME" {
   zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
   name    = "energy-information.alpha.canada.ca"


### PR DESCRIPTION
# Summary
Remove the records for `statistics.alpha.canada.ca` and `statistique.alpha.canada.ca` as these are no longer needed.

This is duplicating @justbert's PR #362 as a way to make sure the Terraform plan runs as expected.

# Related
- Closes #362 