### PR TITLE
feat: add mailchimp dkim CNAME records

### DIFF
--- a/terraform/cds-snc.ca.tf
+++ b/terraform/cds-snc.ca.tf
@@ -306,8 +306,8 @@ resource "aws_route53_record" "freshdesk-dkim-04-cds-snc-ca-CNAME" {
 
 resource "aws_route53_record" "mailchimp-dkim-02-cds-snc-ca-cname" {
   zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
-  name = "k2._domainkey.cds-snc.ca"
-  type = "CNAME"
+  name    = "k2._domainkey.cds-snc.ca"
+  type    = "CNAME"
   records = [
     "dkim2.mcsv.net"
   ]
@@ -316,8 +316,8 @@ resource "aws_route53_record" "mailchimp-dkim-02-cds-snc-ca-cname" {
 
 resource "aws_route53_record" "mailchimp-dkim-03-cds-snc-ca-cname" {
   zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
-  name = "k3._domainkey.cds-snc.ca"
-  type = "CNAME"
+  name    = "k3._domainkey.cds-snc.ca"
+  type    = "CNAME"
   records = [
     "dkim3.mcsv.net"
   ]
@@ -326,8 +326,8 @@ resource "aws_route53_record" "mailchimp-dkim-03-cds-snc-ca-cname" {
 
 resource "aws_route53_record" "mailchimp-dmarc-cds-snc-ca-TXT" {
   zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
-  name = "_dmarc.cds-snc.ca"
-  type = "TXT"
+  name    = "_dmarc.cds-snc.ca"
+  type    = "TXT"
   records = [
     "v=DMARC1, p=none"
   ]

--- a/terraform/cds-snc.ca.tf
+++ b/terraform/cds-snc.ca.tf
@@ -302,6 +302,28 @@ resource "aws_route53_record" "freshdesk-dkim-04-cds-snc-ca-CNAME" {
   ttl = "1800"
 }
 
+# Mailchimp records
+
+resource "aws_route53_record" "mailchimp-dkim-02-cds-snc-ca-cname" {
+  zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
+  name = "k2._domainkey.cds-snc.ca"
+  type = "CNAME"
+  records = [
+    "dkim2.mcsv.net"
+  ]
+  ttl = "1800"
+}
+
+resource "aws_route53_record" "mailchimp-dkim-03-cds-snc-ca-cname" {
+  zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
+  name = "k3._domainkey.cds-snc.ca"
+  type = "CNAME"
+  records = [
+    "dkim3.mcsv.net"
+  ]
+  ttl = "1800"
+}
+
 # Happyfox DKIM records
 resource "aws_route53_record" "happyfox-dkim-01-cds-snc-ca-CNAME" {
   zone_id = aws_route53_zone.cds-snc-ca-public.zone_id

--- a/terraform/cds-snc.ca.tf
+++ b/terraform/cds-snc.ca.tf
@@ -324,6 +324,15 @@ resource "aws_route53_record" "mailchimp-dkim-03-cds-snc-ca-cname" {
   ttl = "1800"
 }
 
+resource "aws_route53_record" "mailchimp-dmarc-cds-snc-ca-TXT" {
+  zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
+  name = "_dmarc.cds-snc.ca"
+  type = "TXT"
+  records = [
+    "v=DMARC1, p=none"
+  ]
+}
+
 # Happyfox DKIM records
 resource "aws_route53_record" "happyfox-dkim-01-cds-snc-ca-CNAME" {
   zone_id = aws_route53_zone.cds-snc-ca-public.zone_id


### PR DESCRIPTION
# Summary | Résumé

Registering Mailchimp with the CDS domain