### PR TITLE
Added inspection.alpha.canada.ca 

### DIFF
--- a/terraform/inspection.alpha.canada.ca.tf
+++ b/terraform/inspection.alpha.canada.ca.tf
@@ -1,0 +1,12 @@
+resource "aws_route53_record" "inspection-alpha-canada-ca-NS" {
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "inspection.alpha.canada.ca"
+  type    = "NS"
+  records = [
+    "ns1-36.azure-dns.com.",
+    "ns2-36.azure-dns.net.",
+    "ns3-36.azure-dns.org.",
+    "ns4-36.azure-dns.info."
+  ]
+  ttl = "21600"
+}


### PR DESCRIPTION
# Summary | Résumé

The aws_route53_record resource creates a Route 53 record for the `inspection.alpha.canada.ca` domain. It sets the record type to NS and uses four Azure DNS servers as nameservers. The record has a TTL of 21600 seconds (6 hours).

About the CFIA ai-lab: https://github.com/ai-cfia