### PR TITLE
feat(dns): Add CNAME for census.alpha.canada.ca

### DIFF
--- a/terraform/statcan.alpha.canada.ca.tf
+++ b/terraform/statcan.alpha.canada.ca.tf
@@ -42,3 +42,43 @@ resource "aws_route53_record" "_acme-challenge-information-energie-alpha-canada-
   ]
   ttl = "300"
 }
+
+resource "aws_route53_record" "census-alpha-canada-ca-CNAME" {
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "census.alpha.canada.ca"
+  type    = "CNAME"
+  records = [
+    "census-cws.prod.cloud.statcan.ca"
+  ]
+  ttl = "300"
+}
+
+resource "aws_route53_record" "_acme-challenge-census-alpha-canada-ca-CNAME" {
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = join(".", [local.acme_challenge, aws_route53_record.census-alpha-canada-ca-CNAME.name])
+  type    = "CNAME"
+  records = [
+    join(".", [aws_route53_record.census-alpha-canada-ca-CNAME.name, local.challenges_subdomain])
+  ]
+  ttl = "300"
+}
+
+resource "aws_route53_record" "recensement-alpha-canada-ca-CNAME" {
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "recensement.alpha.canada.ca"
+  type    = "CNAME"
+  records = [
+    "census-cws.prod.cloud.statcan.ca"
+  ]
+  ttl = "300"
+}
+
+resource "aws_route53_record" "_acme-challenge-recensement-alpha-canada-ca-CNAME" {
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = join(".", [local.acme_challenge, aws_route53_record.recensement-alpha-canada-ca-CNAME.name])
+  type    = "CNAME"
+  records = [
+    join(".", [aws_route53_record.recensement-alpha-canada-ca-CNAME.name, local.challenges_subdomain])
+  ]
+  ttl = "300"
+}


### PR DESCRIPTION
# Summary
Adds the following 2 CNAME records:
- census.alpha.canada.ca
- recensement.alpha.canada.ca

# Related
- Closes https://github.com/cds-snc/dns/pull/377