### PR TITLE
Adding a new iam role that will allow notify to manage notifcation.canada.ca domain

### DIFF
--- a/terraform/notification.canada.ca-role.tf
+++ b/terraform/notification.canada.ca-role.tf
@@ -35,6 +35,7 @@ resource "aws_iam_policy" "prod_dns_manager_policy" {
       },
       {
         Action = [
+          "route53:GetHostedZone",
           "route53:ListHostedZones",
           "route53:GetHostedZoneCount",
           "route53:ListHostedZonesByName"

--- a/terraform/notification.canada.ca-role.tf
+++ b/terraform/notification.canada.ca-role.tf
@@ -1,5 +1,5 @@
 # Define IAM role A with a trust policy that allows it to be assumed by terraform apply oidc role
-resource "aws_iam_role" "prod_dns_manager" {
+resource "aws_iam_role" "notify_prod_dns_manager" {
   name = "notify_prod_dns_manager"
 
   assume_role_policy = jsonencode({

--- a/terraform/notification.canada.ca-role.tf
+++ b/terraform/notification.canada.ca-role.tf
@@ -1,6 +1,6 @@
 # Define IAM role A with a trust policy that allows it to be assumed by terraform apply oidc role
 resource "aws_iam_role" "prod_dns_manager" {
-  name = "prod_dns_manager"
+  name = "notify_prod_dns_manager"
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17",
@@ -17,8 +17,8 @@ resource "aws_iam_role" "prod_dns_manager" {
 }
 
 # Define the IAM policy
-resource "aws_iam_policy" "prod_dns_manager_policy" {
-  name        = "prod_dns_manager_policy"
+resource "aws_iam_policy" "notify_prod_dns_manager_policy" {
+  name        = "notify_prod_dns_manager_policy"
   description = "Policy to manage Route53 records for notification.canada.ca hosted zone"
 
   policy = jsonencode({
@@ -49,6 +49,6 @@ resource "aws_iam_policy" "prod_dns_manager_policy" {
 
 # Attach the policy to the IAM role
 resource "aws_iam_role_policy_attachment" "prod_dns_manager_policy_attachment" {
-  role       = aws_iam_role.prod_dns_manager.name
-  policy_arn = aws_iam_policy.prod_dns_manager_policy.arn
+  role       = aws_iam_role.notify_prod_dns_manager.name
+  policy_arn = aws_iam_policy.notify_prod_dns_manager_policy.arn
 }

--- a/terraform/notification.canada.ca-role.tf
+++ b/terraform/notification.canada.ca-role.tf
@@ -1,0 +1,53 @@
+# Define IAM role A with a trust policy that allows it to be assumed by terraform apply oidc role
+resource "aws_iam_role" "prod_dns_manager" {
+  name = "prod_dns_manager"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Principal = {
+          AWS = "arn:aws:iam::296255494825:role/notification-terraform-apply"
+        },
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+# Define the IAM policy
+resource "aws_iam_policy" "prod_dns_manager_policy" {
+  name        = "prod_dns_manager_policy"
+  description = "Policy to manage Route53 records for notification.canada.ca hosted zone"
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Action = [
+          "route53:ListResourceRecordSets",
+          "route53:ChangeResourceRecordSets",
+          "route53:GetChange"
+        ],
+        Effect   = "Allow",
+        Resource = "arn:aws:route53:::hostedzone/Z1XG153PQF3VV5"
+      },
+      {
+        Action = [
+          "route53:ListHostedZones",
+          "route53:GetHostedZoneCount",
+          "route53:ListHostedZonesByName"
+        ],
+        Effect   = "Allow",
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+# Attach the policy to the IAM role
+resource "aws_iam_role_policy_attachment" "prod_dns_manager_policy_attachment" {
+  role       = aws_iam_role.prod_dns_manager.name
+  policy_arn = aws_iam_policy.prod_dns_manager_policy.arn
+}


### PR DESCRIPTION
# Summary | Résumé

Closes #395 

New IAM role that will allow the following:
1. List hosted zones, get hosted zones count and list hosted zone names permissions.
2. Change hosted zone records only for notification.canada.ca hosted zone.
3. Allow this role to be assumed by the github oidc role 