### PR TITLE
Adding SSO role for notification admins

### DIFF
--- a/terraform/notification.canada.ca-role.tf
+++ b/terraform/notification.canada.ca-role.tf
@@ -8,7 +8,10 @@ resource "aws_iam_role" "notify_prod_dns_manager" {
       {
         Effect = "Allow",
         Principal = {
-          AWS = "arn:aws:iam::296255494825:role/notification-terraform-apply"
+          AWS = [
+            "arn:aws:iam::296255494825:role/notification-terraform-apply",
+            "arn:aws:iam::296255494825:role/aws-reserved/sso.amazonaws.com/ca-central-1/AWSReservedSSO_AWSAdministratorAccess_dcf2167fdeb47617"
+          ]
         },
         Action = "sts:AssumeRole"
       }


### PR DESCRIPTION
# Summary | Résumé

Add SSO role for Administrators that can assume the notify_prod_dns_manager role. 