### PR TITLE
Adding UpdateAssumeRolePolicy permission to the github user

### DIFF
--- a/terraform/github-user.tf
+++ b/terraform/github-user.tf
@@ -54,7 +54,8 @@ resource "aws_iam_policy" "Route53TerraformDeploy" {
           "iam:GetPolicyVersion",
           "iam:GetPolicy",
           "iam:ListAttachedRolePolicies",
-          "iam:ListAttachedUserPolicies"
+          "iam:ListAttachedUserPolicies",
+          "iam:UpdateAssumeRolePolicy"
         ],
         "Resource" : [
           "arn:aws:iam::866996500832:role/notify_prod_dns_manager",


### PR DESCRIPTION
# Summary | Résumé

Adding UpdateAssumeRolePolicy permission to the github user so that we can update the assume role policy. 