### PR TITLE
Making the SSO role secret for enhanced security

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -12,6 +12,7 @@ env:
   AWS_REGION: ca-central-1
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  TF_aws_sso_admin_access_role_arn: ${{ secrets.AWS_SSO_ADMIN_ACCESS_ROLE_ARN }}
   TERRAFORM_VERSION: 1.9.2
   TF_INPUT: false
 

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -12,7 +12,7 @@ env:
   AWS_REGION: ca-central-1
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  TF_aws_sso_admin_access_role_arn: ${{ secrets.AWS_SSO_ADMIN_ACCESS_ROLE_ARN }}
+  TF_VAR_aws_sso_admin_access_role_arn: ${{ secrets.AWS_SSO_ADMIN_ACCESS_ROLE_ARN }}
   TERRAFORM_VERSION: 1.9.2
   TF_INPUT: false
 

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -9,7 +9,7 @@ env:
   AWS_REGION: ca-central-1
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  TF_aws_sso_admin_access_role_arn: ${{ secrets.AWS_SSO_ADMIN_ACCESS_ROLE_ARN }}
+  TF_VAR_aws_sso_admin_access_role_arn: ${{ secrets.AWS_SSO_ADMIN_ACCESS_ROLE_ARN }}
   CONFTEST_VERSION: 0.54.0
   TERRAFORM_VERSION: 1.9.2
   TF_INPUT: false

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -9,6 +9,7 @@ env:
   AWS_REGION: ca-central-1
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  TF_aws_sso_admin_access_role_arn: ${{ secrets.AWS_SSO_ADMIN_ACCESS_ROLE_ARN }}
   CONFTEST_VERSION: 0.54.0
   TERRAFORM_VERSION: 1.9.2
   TF_INPUT: false

--- a/terraform/notification.canada.ca-role.tf
+++ b/terraform/notification.canada.ca-role.tf
@@ -1,4 +1,11 @@
-# Define IAM role A with a trust policy that allows it to be assumed by terraform apply oidc role
+# Define IAM role A with a trust policy that allows it to be assumed by terraform apply role
+
+variable "aws_sso_admin_access_role_arn" {
+  description = "ARN for the AWS SSO Administrator Access role"
+  type        = string
+  sensitive   = true
+}
+
 resource "aws_iam_role" "notify_prod_dns_manager" {
   name = "notify_prod_dns_manager"
 
@@ -10,7 +17,7 @@ resource "aws_iam_role" "notify_prod_dns_manager" {
         Principal = {
           AWS = [
             "arn:aws:iam::296255494825:role/notification-terraform-apply",
-            "arn:aws:iam::296255494825:role/aws-reserved/sso.amazonaws.com/ca-central-1/AWSReservedSSO_AWSAdministratorAccess_*"
+            var.aws_sso_admin_access_role_arn
           ]
         },
         Action = "sts:AssumeRole"


### PR DESCRIPTION
# Summary | Résumé

The terraform apply fails since it does not like wildcards. Upon further research, it seems you can't have wildcards in the principal so I put it in a secret variable. 

![Screenshot 2024-07-16 at 2 35 49 PM](https://github.com/user-attachments/assets/f3eaa31a-416e-4306-93b4-3073dead6e0e)
