### PR TITLE
Adding list tags permissions for Notify IAM

### DIFF
--- a/terraform/notification.canada.ca-role.tf
+++ b/terraform/notification.canada.ca-role.tf
@@ -38,7 +38,8 @@ resource "aws_iam_policy" "notify_prod_dns_manager_policy" {
         Action = [
           "route53:ListResourceRecordSets",
           "route53:ChangeResourceRecordSets",
-          "route53:GetChange"
+          "route53:GetChange",
+          "route53:ListTagsForResource"
         ],
         Effect   = "Allow",
         Resource = "arn:aws:route53:::hostedzone/Z1XG153PQF3VV5"


### PR DESCRIPTION
# Summary | Résumé

Our Terraform is failing:

```
is not authorized to perform: route53:ListTagsForResource on resource: arn:aws:route53:::hostedzone/Z1XG153PQF3VV5 because no identity-based policy allows the route53:ListTagsForResource action
```

Adding in the required permissions

# Test instructions | Instructions pour tester la modification
TF Plan works 🤞 
