### PR TITLE
Github User - Add List Policies

### DIFF
--- a/terraform/github-user.tf
+++ b/terraform/github-user.tf
@@ -55,7 +55,8 @@ resource "aws_iam_policy" "Route53TerraformDeploy" {
           "iam:GetPolicy",
           "iam:ListAttachedRolePolicies",
           "iam:ListAttachedUserPolicies",
-          "iam:UpdateAssumeRolePolicy"
+          "iam:UpdateAssumeRolePolicy",
+          "iam:ListPolicyVersions"
         ],
         "Resource" : [
           "arn:aws:iam::866996500832:role/notify_prod_dns_manager",


### PR DESCRIPTION
# Summary | Résumé

TF Apply is failing due to missing permissions for the github user. 

# Test instructions | Instructions pour tester la modification

TF Apply works