### PR TITLE
Remove notification canada ca

### DIFF
--- a/terraform/notification.alpha.canada.ca.tf
+++ b/terraform/notification.alpha.canada.ca.tf
@@ -1,3 +1,12 @@
+locals {
+  notification_alb                              = "notification-production-alb-1685085140.ca-central-1.elb.amazonaws.com"
+  notification_zone_id                          = "ZQSVJUPU6J1EY"
+  api_gateway_regional_zone_id                  = "Z19DQILCV0OWEC" # ca-central-1
+  api_lambda_gateway_domain_name_api_lambda     = "d-0jho4qbdqi.execute-api.ca-central-1.amazonaws.com"
+  api_lambda_gateway_domain_name_alt_api_lambda = "d-f9v7fu3260.execute-api.ca-central-1.amazonaws.com"
+  api_lambda_gateway_domain_name_api            = "d-jwtzdgd9qg.execute-api.ca-central-1.amazonaws.com"
+}
+
 resource "aws_route53_record" "notification-alpha-canada-ca-ALIAS" {
   zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
   name    = "notification.alpha.canada.ca"

--- a/terraform/notification.canada.ca-role.tf
+++ b/terraform/notification.canada.ca-role.tf
@@ -39,11 +39,18 @@ resource "aws_iam_policy" "notify_prod_dns_manager_policy" {
         Action = [
           "route53:ListResourceRecordSets",
           "route53:ChangeResourceRecordSets",
-          "route53:GetChange",
-          "route53:ListTagsForResource"
+          "route53:ListTagsForResource",
+          "route53:UpdateHostedZoneComment"
         ],
         Effect   = "Allow",
         Resource = "arn:aws:route53:::hostedzone/Z1XG153PQF3VV5"
+      },
+      {
+        Action = [
+          "route53:GetChange"
+        ],
+        Effect   = "Allow",
+        Resource = "arn:aws:route53:::change/*"
       },
       {
         Action = [
@@ -57,10 +64,4 @@ resource "aws_iam_policy" "notify_prod_dns_manager_policy" {
       }
     ]
   })
-}
-
-# Attach the policy to the IAM role
-resource "aws_iam_role_policy_attachment" "prod_dns_manager_policy_attachment" {
-  role       = aws_iam_role.notify_prod_dns_manager.name
-  policy_arn = aws_iam_policy.notify_prod_dns_manager_policy.arn
 }

--- a/terraform/notification.canada.ca-role.tf
+++ b/terraform/notification.canada.ca-role.tf
@@ -65,3 +65,9 @@ resource "aws_iam_policy" "notify_prod_dns_manager_policy" {
     ]
   })
 }
+
+# Attach the policy to the IAM role
+resource "aws_iam_role_policy_attachment" "prod_dns_manager_policy_attachment" {
+  role       = aws_iam_role.notify_prod_dns_manager.name
+  policy_arn = aws_iam_policy.notify_prod_dns_manager_policy.arn
+}

--- a/terraform/notification.canada.ca-zone.tf
+++ b/terraform/notification.canada.ca-zone.tf
@@ -234,14 +234,6 @@ removed {
 }
 
 removed {
-  from = aws_route53_record.status-notification-validation-CNAME
-
-  lifecycle {
-    destroy = false
-  }
-}
-
-removed {
   from = aws_route53_record.system-status-notification-canada-ca-cname
 
   lifecycle {

--- a/terraform/notification.canada.ca-zone.tf
+++ b/terraform/notification.canada.ca-zone.tf
@@ -2,14 +2,6 @@
 ### TO MANAGE NOTIFICATION.CANADA.CA USE NOTIFICATION-TERRAFORM REPO ###
 
 removed {
-  from = aws_route53_zone.notification-canada-ca-public
-
-  lifecycle {
-    destroy = false
-  }
-}
-
-removed {
   from = aws_route53_record.notification-canada-ca-ALIAS
 
   lifecycle {

--- a/terraform/notification.canada.ca-zone.tf
+++ b/terraform/notification.canada.ca-zone.tf
@@ -195,7 +195,7 @@ removed {
 
 removed {
   from = aws_route53_record.notification-canada-ca-DMARC
-  
+
   lifecycle {
     destroy = false
   }
@@ -203,7 +203,7 @@ removed {
 
 removed {
   from = aws_route53_record.amazonses-notification-canada-ca-TXT
-  
+
   lifecycle {
     destroy = false
   }
@@ -211,7 +211,7 @@ removed {
 
 removed {
   from = aws_route53_record.amazonses-mail-from-notification-canada-ca-TXT
-  
+
   lifecycle {
     destroy = false
   }
@@ -219,7 +219,7 @@ removed {
 
 removed {
   from = aws_route53_record.amazonses-mail-from-notification-canada-ca-MX
-  
+
   lifecycle {
     destroy = false
   }
@@ -227,7 +227,7 @@ removed {
 
 removed {
   from = aws_route53_record.amazonses-inbound-notification-canada-ca-MX
-  
+
   lifecycle {
     destroy = false
   }
@@ -235,7 +235,7 @@ removed {
 
 removed {
   from = aws_route53_record.status-notification-validation-CNAME
-  
+
   lifecycle {
     destroy = false
   }
@@ -243,7 +243,7 @@ removed {
 
 removed {
   from = aws_route53_record.system-status-notification-canada-ca-cname
-  
+
   lifecycle {
     destroy = false
   }

--- a/terraform/notification.canada.ca-zone.tf
+++ b/terraform/notification.canada.ca-zone.tf
@@ -1,335 +1,247 @@
-resource "aws_route53_zone" "notification-canada-ca-public" {
-  name    = "notification.canada.ca"
-  comment = ""
+removed {
+  from = aws_route53_zone.notification-canada-ca-public
 
-  tags = {
-    Project = "dns"
+  lifecycle {
+    destroy = false
   }
 }
 
-output "notification-canada-ca-ns" {
-  value = aws_route53_zone.notification-canada-ca-public.name_servers
-}
+removed {
+  from = aws_route53_record.notification-canada-ca-ALIAS
 
-locals {
-  notification_alb                              = "notification-production-alb-1685085140.ca-central-1.elb.amazonaws.com"
-  notification_zone_id                          = "ZQSVJUPU6J1EY"
-  api_gateway_regional_zone_id                  = "Z19DQILCV0OWEC" # ca-central-1
-  api_lambda_gateway_domain_name_api_lambda     = "d-0jho4qbdqi.execute-api.ca-central-1.amazonaws.com"
-  api_lambda_gateway_domain_name_alt_api_lambda = "d-f9v7fu3260.execute-api.ca-central-1.amazonaws.com"
-  api_lambda_gateway_domain_name_api            = "d-jwtzdgd9qg.execute-api.ca-central-1.amazonaws.com"
-}
-
-resource "aws_route53_record" "notification-canada-ca-ALIAS" {
-  zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
-  name    = "notification.canada.ca"
-  type    = "A"
-
-  alias {
-    name                   = local.notification_alb
-    zone_id                = local.notification_zone_id
-    evaluate_target_health = true
+  lifecycle {
+    destroy = false
   }
 }
 
-resource "aws_route53_record" "api-notification-canada-ca-A" {
-  zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
-  name    = "api.notification.canada.ca"
-  type    = "A"
+removed {
+  from = aws_route53_record.api-notification-canada-ca-A
 
-  alias {
-    name                   = local.notification_alb
-    zone_id                = local.notification_zone_id
-    evaluate_target_health = true
-  }
-
-  set_identifier = "loadbalancer"
-  weighted_routing_policy {
-    weight = 0
+  lifecycle {
+    destroy = false
   }
 }
 
-resource "aws_route53_record" "lambda-api-notification-canada-ca-A" {
-  zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
-  name    = "api.notification.canada.ca"
-  type    = "A"
+removed {
+  from = aws_route53_record.lambda-api-notification-canada-ca-A
 
-  alias {
-    name                   = local.api_lambda_gateway_domain_name_api
-    zone_id                = local.api_gateway_regional_zone_id
-    evaluate_target_health = true
-  }
-
-  set_identifier = "lambda"
-  weighted_routing_policy {
-    weight = 100
+  lifecycle {
+    destroy = false
   }
 }
 
-resource "aws_route53_record" "api-k8s-notification-canada-ca-A" {
-  zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
-  name    = "api-k8s.notification.canada.ca"
-  type    = "CNAME"
-  records = [
-    local.notification_alb
-  ]
-  ttl = "300"
-}
+removed {
+  from = aws_route53_record.api-k8s-notification-canada-ca-A
 
-resource "aws_route53_record" "api-lambda-notification-canada-ca-A" {
-  zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
-  name    = "api-lambda.notification.canada.ca"
-  type    = "A"
-
-  alias {
-    name                   = local.api_lambda_gateway_domain_name_api_lambda
-    zone_id                = local.api_gateway_regional_zone_id
-    evaluate_target_health = true
+  lifecycle {
+    destroy = false
   }
 }
 
-resource "aws_route53_record" "document-notification-canada-ca-A" {
-  zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
-  name    = "document.notification.canada.ca"
-  type    = "CNAME"
-  records = [
-    local.notification_alb
-  ]
-  ttl = "300"
+removed {
+  from = aws_route53_record.api-lambda-notification-canada-ca-A
+
+  lifecycle {
+    destroy = false
+  }
 }
 
-resource "aws_route53_record" "api-document-notification-canada-ca-A" {
-  zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
-  name    = "api.document.notification.canada.ca"
-  type    = "CNAME"
-  records = [
-    local.notification_alb
-  ]
-  ttl = "300"
+removed {
+  from = aws_route53_record.document-notification-canada-ca-A
+
+  lifecycle {
+    destroy = false
+  }
 }
 
-resource "aws_route53_record" "www-notification-canada-ca-CNAME" {
-  zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
-  name    = "www.notification.canada.ca"
-  type    = "CNAME"
-  records = [
-    local.notification_alb
-  ]
-  ttl = "300"
+removed {
+  from = aws_route53_record.api-document-notification-canada-ca-A
+
+  lifecycle {
+    destroy = false
+  }
 }
 
-resource "aws_route53_record" "documentation-notification-canada-ca-CNAME" {
-  zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
-  name    = "documentation.notification.canada.ca"
-  type    = "CNAME"
-  records = [
-    local.notification_alb
-  ]
-  ttl = "300"
+removed {
+  from = aws_route53_record.www-notification-canada-ca-CNAME
+
+  lifecycle {
+    destroy = false
+  }
 }
 
-resource "aws_route53_record" "doc-notification-canada-ca-CNAME" {
-  zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
-  name    = "doc.notification.canada.ca"
-  type    = "CNAME"
-  records = [
-    local.notification_alb
-  ]
-  ttl = "300"
+removed {
+  from = aws_route53_record.www-notification-canada-ca-CNAME
+
+  lifecycle {
+    destroy = false
+  }
 }
 
-resource "aws_route53_record" "notification-canada-ca-ACM-cname" {
-  zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
-  name    = "_2115a5004ab7895234c60254e152046b.notification.canada.ca"
-  type    = "CNAME"
-  records = [
-    "_aaacd89cd470de0970c70c7ab1b7d4d5.wggjkglgrm.acm-validations.aws."
-  ]
-  ttl = "300"
+removed {
+  from = aws_route53_record.documentation-notification-canada-ca-CNAME
+
+  lifecycle {
+    destroy = false
+  }
 }
 
-resource "aws_route53_record" "document-notification-canada-ca-ACM-cname" {
-  zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
-  name    = "_db43d1cf891afd4671fb913d18ef0a0e.document.notification.canada.ca"
-  type    = "CNAME"
-  records = [
-    "_130ea19fa1fdd9e59b7632fbac0d7e00.wggjkglgrm.acm-validations.aws."
-  ]
-  ttl = "300"
+removed {
+  from = aws_route53_record.doc-notification-canada-ca-CNAME
+
+  lifecycle {
+    destroy = false
+  }
 }
 
-resource "aws_route53_record" "api-notification-canada-ca-ACM-cname" {
-  zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
-  name    = "_902cdb1a2cb8214fc698261ee3085b64.api.notification.canada.ca."
-  type    = "CNAME"
-  records = [
-    "_ac309158c158035bfb929da1617e2b16.mqzgcdqkwq.acm-validations.aws."
-  ]
-  ttl = "300"
+removed {
+  from = aws_route53_record.notification-canada-ca-ACM-cname
+
+  lifecycle {
+    destroy = false
+  }
 }
 
-resource "aws_route53_record" "assets-notification-canada-ca-ACM-cname" {
-  zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
-  name    = "_4e30c74d7459e0d63bdcdaac7a57fdcf.assets.notification.canada.ca"
-  type    = "CNAME"
-  records = [
-    "_2da9b84f7e094fd64c8930cffe8d9842.wggjkglgrm.acm-validations.aws."
-  ]
-  ttl = "300"
+removed {
+  from = aws_route53_record.document-notification-canada-ca-ACM-cname
+
+  lifecycle {
+    destroy = false
+  }
 }
 
-resource "aws_route53_record" "assets-notification-canada-ca-cname" {
-  zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
-  name    = "assets.notification.canada.ca"
-  type    = "CNAME"
-  records = [
-    "d1spq0ojswv1dj.cloudfront.net"
-  ]
-  ttl = "300"
+removed {
+  from = aws_route53_record.api-notification-canada-ca-ACM-cname
+
+  lifecycle {
+    destroy = false
+  }
 }
 
-resource "aws_route53_record" "dkim1-notification-canada-ca-CNAME" {
-  zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
-  name    = "wrs6wsp65k764hnaouax5t66vfqrbrst._domainkey.notification.canada.ca"
-  type    = "CNAME"
-  records = [
-    "wrs6wsp65k764hnaouax5t66vfqrbrst.dkim.amazonses.com"
-  ]
-  ttl = "300"
+removed {
+  from = aws_route53_record.assets-notification-canada-ca-ACM-cname
+
+  lifecycle {
+    destroy = false
+  }
 }
 
-resource "aws_route53_record" "dkim2-notification-canada-ca-CNAME" {
-  zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
-  name    = "wrtaqi2wdu42zqjzyf3ikn46kzos4f76._domainkey.notification.canada.ca"
-  type    = "CNAME"
-  records = [
-    "wrtaqi2wdu42zqjzyf3ikn46kzos4f76.dkim.amazonses.com"
-  ]
-  ttl = "300"
+removed {
+  from = aws_route53_record.assets-notification-canada-ca-cname
+
+  lifecycle {
+    destroy = false
+  }
 }
 
-resource "aws_route53_record" "dkim3-notification-canada-ca-CNAME" {
-  zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
-  name    = "h2d5mnabqwlnowww7rkgpoagtrxt7d4z._domainkey.notification.canada.ca"
-  type    = "CNAME"
-  records = [
-    "h2d5mnabqwlnowww7rkgpoagtrxt7d4z.dkim.amazonses.com"
-  ]
-  ttl = "300"
+removed {
+  from = aws_route53_record.dkim1-notification-canada-ca-CNAME
+
+  lifecycle {
+    destroy = false
+  }
 }
 
-resource "aws_route53_record" "dkim1-notification-canada-ca-us-east-1-CNAME" {
-  zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
-  name    = "iymb7ahbsrpfy7ktku4tpibh2n3a2hdk._domainkey.notification.canada.ca"
-  type    = "CNAME"
-  records = [
-    "iymb7ahbsrpfy7ktku4tpibh2n3a2hdk.dkim.amazonses.com"
-  ]
-  ttl = "300"
+removed {
+  from = aws_route53_record.dkim2-notification-canada-ca-CNAME
+
+  lifecycle {
+    destroy = false
+  }
 }
 
-resource "aws_route53_record" "dkim2-notification-canada-ca-us-east-1-CNAME" {
-  zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
-  name    = "z7ujljo4n4hbl4slxawnomvstjhlbgx2._domainkey.notification.canada.ca"
-  type    = "CNAME"
-  records = [
-    "z7ujljo4n4hbl4slxawnomvstjhlbgx2.dkim.amazonses.com"
-  ]
-  ttl = "300"
+removed {
+  from = aws_route53_record.dkim3-notification-canada-ca-CNAME
+
+  lifecycle {
+    destroy = false
+  }
 }
 
-resource "aws_route53_record" "dkim3-notification-canada-ca-us-east-1-CNAME" {
-  zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
-  name    = "pjmdrlcl2vsjodh4ruc4v2oogw5cs2cl._domainkey.notification.canada.ca"
-  type    = "CNAME"
-  records = [
-    "pjmdrlcl2vsjodh4ruc4v2oogw5cs2cl.dkim.amazonses.com"
-  ]
-  ttl = "300"
+removed {
+  from = aws_route53_record.dkim1-notification-canada-ca-us-east-1-CNAME
+
+  lifecycle {
+    destroy = false
+  }
 }
 
-resource "aws_route53_record" "notification-canada-ca-SPF" {
-  zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
-  name    = "notification.canada.ca"
-  type    = "TXT"
-  records = [
-    # Used for https://postmaster.google.com
-    "google-site-verification=KMFWVel40xicbDXojkXz_1B2gBlPFSqF69cVdH_dfn0",
-    "google-site-verification=WNq0Z6naWk2E9SfS9eYq6Y6ZHH29nmkgox3chj5I9iE",
-    "v=spf1 include:amazonses.com -all"
-  ]
-  ttl = "300"
+removed {
+  from = aws_route53_record.dkim2-notification-canada-ca-us-east-1-CNAME
+
+  lifecycle {
+    destroy = false
+  }
 }
 
-resource "aws_route53_record" "notification-canada-ca-DMARC" {
-  zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
-  name    = "_dmarc.notification.canada.ca"
-  type    = "TXT"
-  records = [
-    "v=DMARC1; p=reject; sp=reject; pct=100; rua=mailto:dmarc@cyber.gc.ca"
-  ]
-  ttl = "300"
+removed {
+  from = aws_route53_record.dkim3-notification-canada-ca-us-east-1-CNAME
+
+  lifecycle {
+    destroy = false
+  }
 }
 
-resource "aws_route53_record" "amazonses-notification-canada-ca-TXT" {
-  zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
-  name    = "_amazonses.notification.canada.ca"
-  type    = "TXT"
-  records = [
-    # ca-central-1
-    "Ohfl/Syh3ZT5U/7IKELTCXIRaqI42ZJiw0HiUQoCHww=",
-    # us-east-1 for inbound emails
-    "FHX+PBM3ip2HfDeSXs3WpEuQZydluvX9VpOdBKj0dgU="
-  ]
-  ttl = "300"
+removed {
+  from = aws_route53_record.notification-canada-ca-SPF
+
+  lifecycle {
+    destroy = false
+  }
 }
 
-resource "aws_route53_record" "amazonses-mail-from-notification-canada-ca-TXT" {
-  zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
-  name    = "bounce.notification.canada.ca"
-  type    = "TXT"
-  records = [
-    "v=spf1 include:amazonses.com -all"
-  ]
-  ttl = "300"
+removed {
+  from = aws_route53_record.notification-canada-ca-DMARC
+  
+  lifecycle {
+    destroy = false
+  }
 }
 
-resource "aws_route53_record" "amazonses-mail-from-notification-canada-ca-MX" {
-  zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
-  name    = "bounce.notification.canada.ca"
-  type    = "MX"
-  records = [
-    "10 feedback-smtp.ca-central-1.amazonses.com"
-  ]
-  ttl = "300"
+removed {
+  from = aws_route53_record.amazonses-notification-canada-ca-TXT
+  
+  lifecycle {
+    destroy = false
+  }
 }
 
-resource "aws_route53_record" "amazonses-inbound-notification-canada-ca-MX" {
-  zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
-  name    = "notification.canada.ca"
-  type    = "MX"
-  records = [
-    "10 inbound-smtp.us-east-1.amazonaws.com"
-  ]
-  ttl = "300"
+removed {
+  from = aws_route53_record.amazonses-mail-from-notification-canada-ca-TXT
+  
+  lifecycle {
+    destroy = false
+  }
 }
 
-# DNS Validation for status.notification.canada.ca
-resource "aws_route53_record" "status-notification-validation-CNAME" {
-  zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
-  name    = "_7deec9582fbcae0f970d8192e402d455.status.notification.canada.ca"
-  type    = "CNAME"
-  records = ["_460cff15b0106252f78a3e2257c44d80.mhbtsbpdnt.acm-validations.aws."]
-
-  ttl = "300"
+removed {
+  from = aws_route53_record.amazonses-mail-from-notification-canada-ca-MX
+  
+  lifecycle {
+    destroy = false
+  }
 }
 
-resource "aws_route53_record" "system-status-notification-canada-ca-cname" {
-  zone_id = aws_route53_zone.notification-canada-ca-public.zone_id
-  name    = "status.notification.canada.ca"
-  type    = "CNAME"
-  records = [
-    "dko2frhnt892.cloudfront.net"
-  ]
-  ttl = "300"
+removed {
+  from = aws_route53_record.amazonses-inbound-notification-canada-ca-MX
+  
+  lifecycle {
+    destroy = false
+  }
+}
+
+removed {
+  from = aws_route53_record.status-notification-validation-CNAME
+  
+  lifecycle {
+    destroy = false
+  }
+}
+
+removed {
+  from = aws_route53_record.system-status-notification-canada-ca-cname
+  
+  lifecycle {
+    destroy = false
+  }
 }

--- a/terraform/notification.canada.ca-zone.tf
+++ b/terraform/notification.canada.ca-zone.tf
@@ -1,3 +1,6 @@
+### THESE HAVE BEEN REMOVED FROM THE TERRAFORM CODEBASE ###
+### TO MANAGE NOTIFICATION.CANADA.CA USE NOTIFICATION-TERRAFORM REPO ###
+
 removed {
   from = aws_route53_zone.notification-canada-ca-public
 


### PR DESCRIPTION
# Summary | Résumé

Removing references to notification.canada.ca as they are now done in notification-terraform

# Test instructions | Instructions pour tester la modification

TF Apply shows no changes
