### PR TITLE
feat(dns): Add DNS domain for gccloudone alpha initiative

### DIFF
--- a/terraform/gccloudone.alpha.canada.ca.tf
+++ b/terraform/gccloudone.alpha.canada.ca.tf
@@ -13,7 +13,7 @@ resource "aws_route53_record" "aurora-gccloudone-alpha-canada-ca-CNAME" {
   name    = "aurora.gccloudone.alpha.canada.ca"
   type    = "CNAME"
   records = [
-    "aurora.gccloudone.github.io"
+    "gccloudone.github.io"
   ]
   ttl = "300"
 }

--- a/terraform/gccloudone.alpha.canada.ca.tf
+++ b/terraform/gccloudone.alpha.canada.ca.tf
@@ -1,0 +1,19 @@
+resource "aws_route53_record" "gccloudone-alpha-canada-ca-CNAME" {
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "gccloudone.alpha.canada.ca"
+  type    = "CNAME"
+  records = [
+    "gccloudone.github.io"
+  ]
+  ttl = "300"
+}
+
+resource "aws_route53_record" "aurora-gccloudone-alpha-canada-ca-CNAME" {
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "aurora.gccloudone.alpha.canada.ca"
+  type    = "CNAME"
+  records = [
+    "aurora.gccloudone.github.io"
+  ]
+  ttl = "300"
+}


### PR DESCRIPTION
# Summary | Résumé

Adding DNS records for gccloudone initiative at SSC.
