### PR TITLE
Adding gccloudone cname code

### DIFF
--- a/terraform/gccloudone.alpha.canada.ca.tf
+++ b/terraform/gccloudone.alpha.canada.ca.tf
@@ -1,0 +1,19 @@
+resource "aws_route53_record" "gccloudone-alpha-canada-ca-CNAME" {
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "gccloudone.alpha.canada.ca"
+  type    = "CNAME"
+  records = [
+    "gccloudone.github.io"
+  ]
+  ttl = "300"
+}
+
+resource "aws_route53_record" "aurora-gccloudone-alpha-canada-ca-CNAME" {
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "aurora.gccloudone.alpha.canada.ca"
+  type    = "CNAME"
+  records = [
+    "gccloudone.github.io"
+  ]
+  ttl = "300"
+}


### PR DESCRIPTION
# Summary | Résumé

Adds the following CNAME records:

- gccloudone.alpha.canada.ca
- aurora.gccloudone.alpha.canada.ca

## Related:
Closes [feat(dns): Add DNS domain for gccloudone alpha initiative](https://github.com/cds-snc/dns/pull/422)