### PR TITLE
Delegation for Digital Earth Canada (DEC)

### DIFF
--- a/terraform/dec.alpha.canada.ca.tf
+++ b/terraform/dec.alpha.canada.ca.tf
@@ -1,0 +1,12 @@
+resource "aws_route53_record" "dec-alpha-canada-ca-NS" {
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "dec.alpha.canada.ca"
+  type    = "NS"
+  records = [
+    "ns-1030.awsdns-00.org",
+    "ns-8.awsdns-01.com",
+    "ns-1885.awsdns-43.co.uk",
+    "ns-892.awsdns-47.net"
+  ]
+  ttl = "300"
+}


### PR DESCRIPTION
# Summary | Résumé

Creates zone delegation for the Digital Earth Canada PoC being run by CSA/ECCC/NRCan, hosted in SSC Science Program's AWS tenant.

DEC is an effort to centrally provide environments for GoC scientists that use Earth Observartion (EO) data for their tasks. It will host AI/ML platforms, EO data (satellite, plane, drone, etc..) and other tools.


# Test instructions | Instructions pour tester la modification

N/A