### PR TITLE
feat: add CNAMEs for Flood Risk Portal

### DIFF
--- a/terraform/statcan.alpha.canada.ca.tf
+++ b/terraform/statcan.alpha.canada.ca.tf
@@ -82,3 +82,43 @@ resource "aws_route53_record" "_acme-challenge-recensement-alpha-canada-ca-CNAME
   ]
   ttl = "300"
 }
+
+resource "aws_route53_record" "hazard-risk-search-ps-alpha-canada-ca-CNAME" {
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "hazard-risk-search.ps.alpha.canada.ca"
+  type    = "CNAME"
+  records = [
+    "flood-risk-portal.prod.cloud.statcan.ca"
+  ]
+  ttl = "300"
+}
+
+resource "aws_route53_record" "_acme-challenge-hazard-risk-search-ps-alpha-canada-ca-CNAME" {
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = join(".", [local.acme_challenge, aws_route53_record.hazard-risk-search-ps-alpha-canada-ca-CNAME.name])
+  type    = "CNAME"
+  records = [
+    join(".", [aws_route53_record.hazard-risk-search-ps-alpha-canada-ca-CNAME.name, local.challenges_subdomain])
+  ]
+  ttl = "300"
+}
+
+resource "aws_route53_record" "recherche-aleas-risques-ps-alpha-canada-ca-CNAME" {
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "recherche-aleas-risques.ps.alpha.canada.ca"
+  type    = "CNAME"
+  records = [
+    "flood-risk-portal.prod.cloud.statcan.ca"
+  ]
+  ttl = "300"
+}
+
+resource "aws_route53_record" "_acme-challenge-recherche-aleas-risques-ps-alpha-canada-ca-CNAME" {
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = join(".", [local.acme_challenge, aws_route53_record.recherche-aleas-risques-ps-alpha-canada-ca-CNAME.name])
+  type    = "CNAME"
+  records = [
+    join(".", [aws_route53_record.recherche-aleas-risques-ps-alpha-canada-ca-CNAME.name, local.challenges_subdomain])
+  ]
+  ttl = "300"
+}


### PR DESCRIPTION
# Summary
Add CNAMEs to the StatsCan Flood Risk Portal.

# Related
- Closes #431 