### PR TITLE
feat: superset subdomain delegation

### DIFF
--- a/terraform/superset.alpha.canada.ca.tf
+++ b/terraform/superset.alpha.canada.ca.tf
@@ -1,0 +1,12 @@
+resource "aws_route53_record" "superset-alpha-canada-ca-NS" {
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "superset.alpha.canada.ca"
+  type    = "NS"
+  records = [
+    "ns-521.awsdns-01.net",
+    "ns-1259.awsdns-29.org",
+    "ns-1939.awsdns-50.co.uk",
+    "ns-204.awsdns-25.com"
+  ]
+  ttl = "300"
+}


### PR DESCRIPTION
# Summary
Add NS records for the `superset.alpha.canada.ca` hosted zone. This will be used by the production instance of Superset.

# Related
- https://github.com/cds-snc/platform-core-services/issues/617