### PR TITLE
feat: add superset.cds-snc.ca subdomain delegation

### DIFF
--- a/terraform/superset.cds.snc.ca.tf
+++ b/terraform/superset.cds.snc.ca.tf
@@ -1,0 +1,12 @@
+resource "aws_route53_record" "superset-cds-snc-ca-NS" {
+  zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
+  name    = "superset.cds-snc.ca"
+  type    = "NS"
+  records = [
+    "ns-900.awsdns-48.net",
+    "ns-1806.awsdns-33.co.uk",
+    "ns-283.awsdns-35.com",
+    "ns-1176.awsdns-19.org"
+  ]
+  ttl = "300"
+}


### PR DESCRIPTION
# Summary
Add a new NS record so that we can move the production instance of Superset to the cds-snc.ca domain.

⚠️ Once the move is complete, I'll get a PR in to remove the `superset.alpha.canada.ca` NS record.

# Related
- https://github.com/cds-snc/platform-core-services/issues/617