### PR TITLE
feat: add the Qualtrics vanity CNAME record

### DIFF
--- a/terraform/cds-snc.ca.tf
+++ b/terraform/cds-snc.ca.tf
@@ -403,3 +403,15 @@ resource "aws_route53_record" "valentine-cds-snc-NS" {
   ]
   ttl = "1800"
 }
+
+
+# Qualtrics
+resource "aws_route53_record" "qualtrics-cds-snc-CNAME" {
+  zone_id = aws_route53_zone.cds-snc-ca-public.zone_id
+  name    = "experience.cds-snc.ca"
+  type    = "CNAME"
+  records = [
+    cdssnc-primary.vanitydomains.qualtrics.com
+  ]
+  ttl = "1800"
+}


### PR DESCRIPTION
# Summary | Résumé

Create a new record for Qualtrics vanity URL so that the links are more user friendly.