### PR TITLE
feat: update gccatalogue.alpha.canada.ca to CNAME

### DIFF
--- a/terraform/gccatalogue.alpha.canada.ca.tf
+++ b/terraform/gccatalogue.alpha.canada.ca.tf
@@ -1,12 +1,9 @@
-resource "aws_route53_record" "gccatalogue-alpha-canada-ca-NS" {
+resource "aws_route53_record" "gccatalogue-alpha-canada-ca-CNAME" {
   zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
   name    = "gccatalogue.alpha.canada.ca"
-  type    = "NS"
+  type    = "CNAME"
   records = [
-    "ns1-02.azure-dns.com",
-    "ns2-02.azure-dns.net",
-    "ns3-02.azure.dns.org",
-    "ns4-02.azure-dns.info"
+    "gcdigitalpolicy.github.io"
   ]
   ttl = "300"
 }


### PR DESCRIPTION
# Summary
Update to a CNAME record so that the site can be hosted on GitHub pages.

Co-authored by: @nd-tbs

# Related
- Closes #457 
- Closes #455