### PR TITLE
NS records for ai-answers.alpha.canada.ca 

### DIFF
--- a/terraform/ai-answers.alpha.canada.ca.tf
+++ b/terraform/ai-answers.alpha.canada.ca.tf
@@ -1,0 +1,12 @@
+resource "aws_route53_record" "ai-answers-alpha-canada-ca-NS" {
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "ai-answers.alpha.canada.ca"
+  type    = "NS"
+  records = [
+    "ns-340.awsdns-42.com.",
+    "ns-1303.awsdns-34.org.",
+    "ns-1561.awsdns-03.co.uk.",
+    "ns-981.awsdns-58.net."
+  ]
+  ttl = "300"
+}


### PR DESCRIPTION
# Summary | Résumé

Closes #460 
Adding NS records for ai-answers.alpha.canada.ca