### PR TITLE
Adding innovation.alpha.canada.ca TF record

### DIFF
--- a/terraform/innovation.alpha.canada.ca.tf
+++ b/terraform/innovation.alpha.canada.ca.tf
@@ -7,6 +7,6 @@ resource "aws_route53_record" "innovation-alpha-canada-ca-NS" {
     "ns2-04.azure-dns.net.",
     "ns3-04.azure-dns.org.",
     "ns4-04.azure-dns.info."
-]
+  ]
   ttl = "300"
 }

--- a/terraform/innovation.alpha.canada.ca.tf
+++ b/terraform/innovation.alpha.canada.ca.tf
@@ -1,0 +1,12 @@
+resource "aws_route53_record" "innovation-alpha-canada-ca-NS" {
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "innovation.alpha.canada.ca"
+  type    = "NS"
+  records = [
+    "ns1-04.azure-dns.com.",
+    "ns2-04.azure-dns.net.",
+    "ns3-04.azure-dns.org.",
+    "ns4-04.azure-dns.info."
+]
+  ttl = "300"
+}


### PR DESCRIPTION
# Summary | Résumé

DNS record for innovation.alpha.canada.ca as referenced in this PR - https://github.com/cds-snc/dns/pull/462
