### PR TITLE
feat: add a CNAME for reponses-ia.alpha.canada.ca

### DIFF
--- a/terraform/ai-answers.alpha.canada.ca.tf
+++ b/terraform/ai-answers.alpha.canada.ca.tf
@@ -10,3 +10,13 @@ resource "aws_route53_record" "ai-answers-alpha-canada-ca-NS" {
   ]
   ttl = "300"
 }
+
+resource "aws_route53_record" "reponses-ia-alpha-canada-ca-CNAME" {
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "reponses-ia.alpha.canada.ca"
+  type    = "CNAME"
+  ttl     = "300"
+  records = [
+    "ai-answers.alpha.canada.ca."
+  ]
+}


### PR DESCRIPTION
# Summary
This will reference the A record for ai-answers.alpha.canada.ca that exists in the hosted zone already.

# Related
- Closes #477 