### PR TITLE
Delegate GC Issue and Verify alpha.canada.ca subdomains to Azure

### DIFF
--- a/terraform/issue-verify.alpha.canada.ca.tf
+++ b/terraform/issue-verify.alpha.canada.ca.tf
@@ -3,10 +3,10 @@ resource "aws_route53_record" "issue-verify-alpha-canada-ca-NS" {
   name    = "issue-verify.alpha.canada.ca"
   type    = "NS"
   records = [
-    "ns-1714.awsdns-22.co.uk",
-    "ns-566.awsdns-06.net",
-    "ns-446.awsdns-55.com",
-    "ns-1257.awsdns-29.org"
+    "ns1-08.azure-dns.com",
+    "ns2-08.azure-dns.net",
+    "ns3-08.azure-dns.org",
+    "ns4-08.azure-dns.info"
   ]
   ttl = "300"
 }
@@ -16,10 +16,10 @@ resource "aws_route53_record" "deliverance-verification-alpha-canada-ca-NS" {
   name    = "deliverance-verification.alpha.canada.ca"
   type    = "NS"
   records = [
-    "ns-1965.awsdns-53.co.uk",
-    "ns-579.awsdns-08.net",
-    "ns-1385.awsdns-45.org",
-    "ns-46.awsdns-05.com"
+    "ns1-08.azure-dns.com",
+    "ns1-08.azure-dns.com",
+    "ns3-08.azure-dns.org",
+    "ns4-08.azure-dns.info"
   ]
   ttl = "300"
 }


### PR DESCRIPTION
# Summary | Résumé

issue-verify.alpha.canada.ca and deliverance-verification.alpha.canada.ca have been created in Azure, and we need to create delegation for these so that DNS for the subdomain can be managed in Azure.  These subdomains will be used for the upcoming partner-test and prod GC Issue and Verify environments.


# Test instructions | Instructions pour tester la modification

We'll be testing the delegation after they're in place when we deploy our partner-test and prod environments.