### PR TITLE
Delegation of gciv-dvgc.alpha.canada.ca to Azure DNS

### DIFF
--- a/terraform/gciv-dvgc.alpha.canada.ca.tf
+++ b/terraform/gciv-dvgc.alpha.canada.ca.tf
@@ -3,10 +3,10 @@ resource "aws_route53_record" "gciv-dvgc-alpha-canada-ca-NS" {
   name    = "gciv-dvgc.alpha.canada.ca"
   type    = "NS"
   records = [
-    "ns-324.awsdns-40.com",
-    "ns-1309.awsdns-35.org",
-    "ns-796.awsdns-35.net",
-    "ns-1876.awsdns-42.co.uk"
+    "ns1-08.azure-dns.com",
+    "ns2-08.azure-dns.net",
+    "ns3-08.azure-dns.org",
+    "ns4-08.azure-dns.info"
   ]
   ttl = "300"
 }


### PR DESCRIPTION
# Summary | Résumé

Delegation of gciv-dvgc.alpha.canada.ca to Azure DNS
The zone is managed in Azure and will be used primarily by the CDN instance for GC Issue & Verify

# Test instructions | Instructions pour tester la modification

I will conduct some DNS lookups to test this after it's implemented.