### PR TITLE
Add additional permisson to update the policy version 

### DIFF
--- a/terraform/github-user.tf
+++ b/terraform/github-user.tf
@@ -108,6 +108,7 @@ resource "aws_iam_policy" "Route53TerraformDeploy" {
           "iam:ListAttachedUserPolicies",
           "iam:UpdateAssumeRolePolicy",
           "iam:ListPolicyVersions",
+          "iam:DeletePolicyVersion"
         ],
         "Resource" : [
           "arn:aws:iam::866996500832:role/notify_prod_dns_manager",


### PR DESCRIPTION
# Summary | Résumé

Needed to add the following permission so that the policy can be updated. This is due to the apply failure here - https://github.com/cds-snc/dns/actions/runs/22152952406/job/64049976330

```
Error: deleting IAM Policy (arn:aws:iam::866996500832:policy/Route53TerraformDeploy) version (v12): operation error IAM: DeletePolicyVersion, https response error StatusCode: 403, RequestID: c7309d1c-67e6-4a47-8765-a187ae261c2f, api error AccessDenied: User: arn:aws:iam::866996500832:user/dns-github-deployer is not authorized to perform: iam:DeletePolicyVersion on resource: policy arn:aws:iam::866996500832:policy/Route53TerraformDeploy because no identity-based policy allows the iam:DeletePolicyVersion action
│ 
│   with aws_iam_policy.Route53TerraformDeploy,
│   on github-user.tf line 15, in resource "aws_iam_policy" "Route53TerraformDeploy":
│   15: resource "aws_iam_policy" "Route53TerraformDeploy" {
│ 
╵
```