### PR TITLE
move alpha to k8s

### DIFF
--- a/terraform/notification.alpha.canada.ca.tf
+++ b/terraform/notification.alpha.canada.ca.tf
@@ -2,9 +2,7 @@ locals {
   notification_alb                              = "notification-production-alb-1685085140.ca-central-1.elb.amazonaws.com"
   notification_zone_id                          = "ZQSVJUPU6J1EY"
   api_gateway_regional_zone_id                  = "Z19DQILCV0OWEC" # ca-central-1
-  api_lambda_gateway_domain_name_api_lambda     = "d-0jho4qbdqi.execute-api.ca-central-1.amazonaws.com"
-  api_lambda_gateway_domain_name_alt_api_lambda = "d-f9v7fu3260.execute-api.ca-central-1.amazonaws.com"
-  api_lambda_gateway_domain_name_api            = "d-jwtzdgd9qg.execute-api.ca-central-1.amazonaws.com"
+  api_k8s_domain_name                           = "notification-production-alb-1685085140.ca-central-1.elb.amazonaws.com"
 }
 
 resource "aws_route53_record" "notification-alpha-canada-ca-ALIAS" {
@@ -23,10 +21,11 @@ resource "aws_route53_record" "api-notification-alpha-canada-ca-A" {
   zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
   name    = "api.notification.alpha.canada.ca"
   type    = "A"
+  set_identifier  = "loadbalancer"
 
   alias {
-    name                   = local.api_lambda_gateway_domain_name_alt_api_lambda
-    zone_id                = local.api_gateway_regional_zone_id
+    name                   = local.api_k8s_domain_name
+    zone_id                = local.notification_zone_id
     evaluate_target_health = true
   }
 }

--- a/terraform/notification.alpha.canada.ca.tf
+++ b/terraform/notification.alpha.canada.ca.tf
@@ -1,7 +1,7 @@
 locals {
-  notification_alb                              = "notification-production-alb-1685085140.ca-central-1.elb.amazonaws.com"
-  notification_zone_id                          = "ZQSVJUPU6J1EY"
-  api_gateway_regional_zone_id                  = "Z19DQILCV0OWEC" # ca-central-1
+  notification_alb             = "notification-production-alb-1685085140.ca-central-1.elb.amazonaws.com"
+  notification_zone_id         = "ZQSVJUPU6J1EY"
+  api_gateway_regional_zone_id = "Z19DQILCV0OWEC" # ca-central-1
 }
 
 resource "aws_route53_record" "notification-alpha-canada-ca-ALIAS" {
@@ -17,10 +17,10 @@ resource "aws_route53_record" "notification-alpha-canada-ca-ALIAS" {
 }
 
 resource "aws_route53_record" "api-notification-alpha-canada-ca-A" {
-  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
-  name    = "api.notification.alpha.canada.ca"
-  type    = "A"
-  set_identifier  = "loadbalancer"
+  zone_id        = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name           = "api.notification.alpha.canada.ca"
+  type           = "A"
+  set_identifier = "loadbalancer"
 
   alias {
     name                   = local.notification_alb

--- a/terraform/notification.alpha.canada.ca.tf
+++ b/terraform/notification.alpha.canada.ca.tf
@@ -2,7 +2,6 @@ locals {
   notification_alb                              = "notification-production-alb-1685085140.ca-central-1.elb.amazonaws.com"
   notification_zone_id                          = "ZQSVJUPU6J1EY"
   api_gateway_regional_zone_id                  = "Z19DQILCV0OWEC" # ca-central-1
-  api_k8s_domain_name                           = "notification-production-alb-1685085140.ca-central-1.elb.amazonaws.com"
 }
 
 resource "aws_route53_record" "notification-alpha-canada-ca-ALIAS" {
@@ -24,7 +23,7 @@ resource "aws_route53_record" "api-notification-alpha-canada-ca-A" {
   set_identifier  = "loadbalancer"
 
   alias {
-    name                   = local.api_k8s_domain_name
+    name                   = local.notification_alb
     zone_id                = local.notification_zone_id
     evaluate_target_health = true
   }

--- a/terraform/notification.alpha.canada.ca.tf
+++ b/terraform/notification.alpha.canada.ca.tf
@@ -17,9 +17,9 @@ resource "aws_route53_record" "notification-alpha-canada-ca-ALIAS" {
 }
 
 resource "aws_route53_record" "api-notification-alpha-canada-ca-A" {
-  zone_id        = aws_route53_zone.alpha-canada-ca-public.zone_id
-  name           = "api.notification.alpha.canada.ca"
-  type           = "A"
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "api.notification.alpha.canada.ca"
+  type    = "A"
 
   alias {
     name                   = local.notification_alb

--- a/terraform/notification.alpha.canada.ca.tf
+++ b/terraform/notification.alpha.canada.ca.tf
@@ -20,7 +20,6 @@ resource "aws_route53_record" "api-notification-alpha-canada-ca-A" {
   zone_id        = aws_route53_zone.alpha-canada-ca-public.zone_id
   name           = "api.notification.alpha.canada.ca"
   type           = "A"
-  set_identifier = "loadbalancer"
 
   alias {
     name                   = local.notification_alb


### PR DESCRIPTION
# Summary | Résumé

We are moving the notify API back to K8s from lambda. This changes the alpha dns appropriately.

# Test instructions | Instructions pour tester la modification

After apply nslookup api.notification.alpha.canada.ca to verify it's hitting the eks alb and not the lambda api gateway.