### PR TITLE
alpha and code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @cds-snc/internal-sre @patheard 
+terraform/notification* @ben851 @jimleroyer @ponderosa @cds-stephenchow

--- a/terraform/notification.alpha.canada.ca.tf
+++ b/terraform/notification.alpha.canada.ca.tf
@@ -1,10 +1,7 @@
 locals {
-  notification_alb                              = "notification-production-alb-1685085140.ca-central-1.elb.amazonaws.com"
-  notification_zone_id                          = "ZQSVJUPU6J1EY"
-  api_gateway_regional_zone_id                  = "Z19DQILCV0OWEC" # ca-central-1
-  api_lambda_gateway_domain_name_api_lambda     = "d-0jho4qbdqi.execute-api.ca-central-1.amazonaws.com"
-  api_lambda_gateway_domain_name_alt_api_lambda = "d-f9v7fu3260.execute-api.ca-central-1.amazonaws.com"
-  api_lambda_gateway_domain_name_api            = "d-jwtzdgd9qg.execute-api.ca-central-1.amazonaws.com"
+  notification_alb             = "notification-production-alb-1685085140.ca-central-1.elb.amazonaws.com"
+  notification_zone_id         = "ZQSVJUPU6J1EY"
+  api_gateway_regional_zone_id = "Z19DQILCV0OWEC" # ca-central-1
 }
 
 resource "aws_route53_record" "notification-alpha-canada-ca-ALIAS" {
@@ -25,8 +22,8 @@ resource "aws_route53_record" "api-notification-alpha-canada-ca-A" {
   type    = "A"
 
   alias {
-    name                   = local.api_lambda_gateway_domain_name_alt_api_lambda
-    zone_id                = local.api_gateway_regional_zone_id
+    name                   = local.notification_alb
+    zone_id                = local.notification_zone_id
     evaluate_target_health = true
   }
 }


### PR DESCRIPTION
# Summary | Résumé

Let notify-dev be a code owner for notification* TF files, and set alpha api back to K8s

# Test instructions | Instructions pour tester la modification

Make sure you can still hit https://api.notification.alpha.canada.ca
