### PR TITLE
Create delegation for eolakewatch.alpha.canada.ca

### DIFF
--- a/terraform/eolakewatch.alpha.canada.ca.tf
+++ b/terraform/eolakewatch.alpha.canada.ca.tf
@@ -1,0 +1,12 @@
+resource "aws_route53_record" "eolakewatch-alpha-canada-ca-NS" {
+  zone_id = aws_route53_zone.alpha-canada-ca-public.zone_id
+  name    = "eolakewatch.alpha.canada.ca"
+  type    = "NS"
+  records = [
+    "ns1-03.azure-dns.com.",
+    "ns2-03.azure-dns.net.",
+    "ns3-03.azure-dns.org.",
+    "ns4-03.azure-dns.info."
+  ]
+  ttl = "300"
+}


### PR DESCRIPTION
# Summary | Résumé

Creates zone delegation for the ECCC Lakewatch (EOLakewatch) application.

This is an application owned by ECCC, but hosted in the SSC GCCO:LaunchPad innovation space.

# Test instructions | Instructions pour tester la modification

N/A

---

N/A
